### PR TITLE
fix: detached glass shows 'null' in header when pane has no title

### DIFF
--- a/dev/features/bwin-detached-glass.js
+++ b/dev/features/bwin-detached-glass.js
@@ -65,7 +65,7 @@ const settings = {
           content: createGlassContent('top-right'),
           title: 'Top-right pane',
         },
-        { position: 'bottom', size: '70%', content: parentElem, title: 'Bottom pane' },
+        { position: 'bottom', size: '70%', content: parentElem },
       ],
     },
   ],

--- a/src/binary-window/glass/action.detach.js
+++ b/src/binary-window/glass/action.detach.js
@@ -25,14 +25,7 @@ export default {
     
     detachedGlass.contentElement.replaceWith(glassContentEl);
 
-    if (detachedGlass.titleElement) {
-      detachedGlass.titleElement.replaceWith(glassTitleEl);
-    }
-    else {
-      const titleEl = document.createElement('bw-glass-title');
-      detachedGlass.headerElement.prepend(titleEl);
-      titleEl.replaceWith(glassTitleEl);
-    }
+    detachedGlass.titleElement.replaceWith(glassTitleEl);
 
     binaryWindow.removePane(paneSashId);
   },

--- a/src/binary-window/glass/class.js
+++ b/src/binary-window/glass/class.js
@@ -32,9 +32,9 @@ export class Glass {
     if (Array.isArray(this.tabs) && this.tabs.length > 0) {
       headerEl.append(this.createTabs());
     }
-    else if (this.title) {
+    else {
       const titleEl = document.createElement('bw-glass-title');
-      titleEl.append(createDomNode(this.title));
+      if (this.title) titleEl.append(createDomNode(this.title));
       headerEl.append(titleEl);
     }
 


### PR DESCRIPTION
## Problem

Detaching a glass from a pane that has no title rendered the literal text `null` in the detached glass's header.

## Root cause

`Glass.build()` only created a `bw-glass-title` element when a title was present. So when detaching a titleless pane:

- The source pane had no `bw-glass-title` → `paneEl.querySelector('bw-glass-title')` returned `null`.
- The newly created detached glass also had no title element → `detachedGlass.titleElement` was `null`.
- The fallback branch ran `titleEl.replaceWith(glassTitleEl)` where `glassTitleEl` was `null`. `ChildNode.replaceWith(null)` coerces `null` to the **string** `"null"`, inserting it as a visible text node.

## Fix

- `Glass` now always creates a `bw-glass-title` element, leaving it empty when no title is passed.
- With the title element guaranteed to exist, the detach handler's null-title fallback branch is dead code and is removed.

## Test plan

- Detach a pane **with** a title → title carries over as before.
- Detach a pane **without** a title → empty header, no `null` text.
- `dev/features/bwin-detached-glass.js`: the bottom pane is now titleless to exercise this case manually.