### PR TITLE
fix: detached glass empty after edge-split drop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ bwin borrows real window-construction terms — match their meaning in code, com
 
 - Comment only when it adds something the code doesn't already say.
 - Keep comments to 2 lines max, 100 chars per line. If one genuinely needs more, prefix it with `RATIONAL:`.
+- Wrap code keywords in backticks — API/method names, variable names, identifiers (e.g. `addPane`, `activeDragGlassEl`).
 
 ## Debug sentinel values
 

--- a/src/binary-window/glass/drag.js
+++ b/src/binary-window/glass/drag.js
@@ -24,7 +24,9 @@ export default {
       this.removePane(oldSashId);
 
       const newPaneSash = this.addPane(sash.id, { position: dropArea, id: oldSashId });
-      newPaneSash.domNode.append(activeDragGlassEl);
+      // `addPane` seeds the pane with an empty placeholder glass; replace it with
+      // the dragged glass so the pane holds exactly one (the real) glass.
+      newPaneSash.domNode.replaceChildren(activeDragGlassEl);
     }
   },
 


### PR DESCRIPTION
## Problem

After dragging a glass and dropping it onto a pane **edge** (top/right/bottom/left), clicking the glass's **detach** button produced an empty detached glass — no title, no content.

## Root cause

The edge-split drop path in `src/binary-window/glass/drag.js` did:

```js
const newPaneSash = this.addPane(sash.id, { position: dropArea, id: oldSashId });
newPaneSash.domNode.append(activeDragGlassEl);
```

But `BinaryWindow.addPane` always seeds the new pane with its own empty placeholder `Glass`. Appending the dragged glass left the pane with **two** `bw-glass` elements (empty first, real second). The detach action reads the glass via `paneEl.querySelector('bw-glass-content')`, which returns the **first** (empty) match — hence the blank detached glass.

The center-swap path was unaffected.

## Fix

Use `replaceChildren` instead of `append`, so the relocated pane holds exactly the dragged glass.

## Notes

- Verified with a scratch test driving the real `onPaneDrop` handler (failed before, passed after); full suite green (26/26).
- Also tightens the Comments convention in CLAUDE.md (backtick code keywords).
