### PR TITLE
refactor: make sash.store the single source of truth for glass content

### DIFF
--- a/src/binary-window/binary-window.js
+++ b/src/binary-window/binary-window.js
@@ -34,6 +34,9 @@ export class BinaryWindow extends Frame {
     paneEl.innerHTML = '';
     paneEl.append(glass.domNode);
 
+    // Track the live wrappers so a later move carries these exact nodes, not a rebuild.
+    sash.setStore({ content: glass.contentElement, title: glass.titleElement });
+
     if (this.debug) {
       glass.contentElement.prepend(`${sash.id}`);
     }
@@ -52,9 +55,10 @@ export class BinaryWindow extends Frame {
    */
   addPane(targetPaneSashId, props) {
     const { position, size, id, ...glassProps } = props;
-    const paneSash = super.addPane(targetPaneSashId, { position, size, id });
-    const glass = new Glass({ ...glassProps, sash: paneSash, binaryWindow: this });
-    paneSash.domNode.append(glass.domNode);
+    // Seed the new sash's store, then render from it via onPaneCreate — one glass,
+    // built the same way as initial render, with live-wrapper write-back.
+    const paneSash = super.addPane(targetPaneSashId, { position, size, id, store: glassProps });
+    this.onPaneCreate(paneSash.domNode, paneSash);
     return paneSash;
   }
 

--- a/src/binary-window/detached-glass/action.attach.js
+++ b/src/binary-window/detached-glass/action.attach.js
@@ -1,5 +1,3 @@
-import { extractChildNodes } from '@/utils';
-
 export default {
   label: '',
   className: 'bw-glass-action--attach',
@@ -24,15 +22,9 @@ export default {
       size = 0.5;
     }
 
-    // Pass the inner nodes, not the bw-glass-content wrapper — Glass adds its own.
-    const contentEl = detachedGlassEl.querySelector('bw-glass-content');
-
-    binaryWindow.addPane(targetSashId, {
-      position,
-      size,
-      content: extractChildNodes(contentEl),
-      title: detachedGlassEl.querySelector('bw-glass-title')?.textContent || '',
-    });
+    // Restore from the stashed store — content/title/tabs/actions/flags all return.
+    // Its live content/title wrappers are adopted back out of the detached glass.
+    binaryWindow.addPane(targetSashId, { position, size, ...detachedGlassEl.bwStore });
 
     binaryWindow.removeDetachedGlass(detachedGlassEl.id);
   },

--- a/src/binary-window/glass/action.detach.js
+++ b/src/binary-window/glass/action.detach.js
@@ -7,26 +7,25 @@ export default {
     if (!binaryWindow.addDetachedGlass) throw new Error('[bwin] Failed to detach glass from pane');
 
     const paneEl = event.target.closest('bw-pane');
-    const glassContentEl = paneEl.querySelector('bw-glass-content');
-    const glassTitleEl = paneEl.querySelector('bw-glass-title');
+    const paneSashId = paneEl.getAttribute('sash-id');
+    const paneSash = binaryWindow.rootSash.getById(paneSashId);
 
     const windowRect = binaryWindow.windowElement.getBoundingClientRect();
     const width = windowRect.width - DETACHED_GLASS_INSET * 2;
     const height = windowRect.height - DETACHED_GLASS_INSET * 2;
-    const detachedGlass = binaryWindow.addDetachedGlass({ position: 'center', width, height });
 
-    const paneSashId = paneEl.getAttribute('sash-id');
-    const paneSash = binaryWindow.rootSash.getById(paneSashId);
+    // Build from the sash store (source of truth). Drop `actions` so the detached glass
+    // uses its own defaults (attach/minimize/close), not the attached glass's actions.
+    // The live content/title wrappers in the store are adopted into the detached glass.
+    const { actions, ...glassStore } = paneSash.store;
+    const detachedGlass = binaryWindow.addDetachedGlass({ position: 'center', width, height, ...glassStore });
+
     const siblingSashId = paneSash.parent.getChildSiblingById(paneSashId).id;
-
     detachedGlass.domNode.bwOriginalSiblingSashId = siblingSashId;
     detachedGlass.domNode.bwOriginalPosition = paneEl.getAttribute('position');
     detachedGlass.domNode.bwOriginalRelativeSize = paneSash.getRelativeSize();
-    
-    detachedGlass.contentElement.replaceWith(glassContentEl);
-    
-    // Attached glass may only render tabs without title element
-    if (glassTitleEl) detachedGlass.titleElement.replaceWith(glassTitleEl);
+    // Stash the full original store so attach can restore the glass faithfully.
+    detachedGlass.domNode.bwStore = paneSash.store;
 
     binaryWindow.removePane(paneSashId);
   },

--- a/src/binary-window/glass/class.js
+++ b/src/binary-window/glass/class.js
@@ -4,6 +4,20 @@ import minimizeAction from './action.minimize';
 import detachAction from './action.detach';
 
 export const DEFAULT_GLASS_ACTIONS = [minimizeAction, detachAction, closeAction];
+
+// Reuse `value` as the wrapper when it's already the live wrapper element (a move
+// carries the same node); otherwise create a fresh wrapper and fill it from string/Node.
+function buildWrapper(tagName, value) {
+  if (value instanceof Element && value.tagName.toLowerCase() === tagName) {
+    return value;
+  }
+
+  const wrapperEl = document.createElement(tagName);
+  const node = createDomNode(value);
+  node && wrapperEl.append(node);
+  return wrapperEl;
+}
+
 export class Glass {
   domNode;
 
@@ -33,18 +47,13 @@ export class Glass {
       headerEl.append(this.createTabs());
     }
     else {
-      const titleEl = document.createElement('bw-glass-title');
-      if (this.title) titleEl.append(createDomNode(this.title));
-      headerEl.append(titleEl);
+      headerEl.append(buildWrapper('bw-glass-title', this.title));
     }
 
     headerEl.setAttribute('can-drag', this.draggable);
     headerEl.append(this.createActions());
 
-    const contentEl = document.createElement('bw-glass-content');
-    const contentNode = createDomNode(this.content);
-
-    contentNode && contentEl.append(contentNode);
+    const contentEl = buildWrapper('bw-glass-content', this.content);
 
     this.domNode = document.createElement('bw-glass');
     this.domNode.append(headerEl, contentEl);

--- a/src/binary-window/glass/drag.js
+++ b/src/binary-window/glass/drag.js
@@ -21,12 +21,12 @@ export default {
     // Add the pane of glass next to the current pane, vertically or horizontally
     else {
       const oldSashId = getSashIdFromPane(activeDragGlassEl);
+      // Capture the source store before removal; its live wrappers flow into the new
+      // pane, so addPane re-renders the real glass (no manual DOM move needed).
+      const sourceStore = this.rootSash.getById(oldSashId).store;
       this.removePane(oldSashId);
 
-      const newPaneSash = this.addPane(sash.id, { position: dropArea, id: oldSashId });
-      // `addPane` seeds the pane with an empty placeholder glass; replace it with
-      // the dragged glass so the pane holds exactly one (the real) glass.
-      newPaneSash.domNode.replaceChildren(activeDragGlassEl);
+      this.addPane(sash.id, { position: dropArea, id: oldSashId, ...sourceStore });
     }
   },
 

--- a/src/binary-window/store-sot.test.js
+++ b/src/binary-window/store-sot.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { BinaryWindow } from './binary-window';
+
+// `store` is the single source of truth for glass content. These cover the moves that
+// historically read the DOM instead — swap, edge-split drop, and detach/attach.
+describe('sash.store single source of truth', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    Object.defineProperty(container, 'getBoundingClientRect', {
+      value: () => ({ width: 800, height: 600, left: 0, top: 0, right: 800, bottom: 600 }),
+    });
+    document.body.append(container);
+  });
+
+  function mountTwoPanes(extraA = {}) {
+    const win = new BinaryWindow({
+      width: 800,
+      height: 600,
+      children: [
+        { id: 'A', size: '50%', title: 'Title A', content: '<p>Content A</p>', ...extraA },
+        { id: 'B', size: '50%', title: 'Title B', content: '<p>Content B</p>' },
+      ],
+    });
+    win.mount(container);
+    return win;
+  }
+
+  const titleOf = (win, sashId) =>
+    win.windowElement.querySelector(`[sash-id="${sashId}"] bw-glass-title`)?.textContent;
+  const contentOf = (win, sashId) =>
+    win.windowElement.querySelector(`[sash-id="${sashId}"] bw-glass-content`)?.textContent;
+
+  it('swap: store and DOM stay in sync', () => {
+    const win = mountTwoPanes();
+    const paneA = win.windowElement.querySelector('[sash-id="A"]');
+    const paneB = win.windowElement.querySelector('[sash-id="B"]');
+
+    win.activeDropPaneEl = paneB;
+    win.swapPanes(paneA, paneB);
+
+    // Sash A now shows B's content, and its store agrees with the DOM.
+    expect(titleOf(win, 'A')).toBe('Title B');
+    expect(titleOf(win, 'B')).toBe('Title A');
+    const sashA = win.rootSash.getById('A');
+    expect(sashA.store.title).toBe(win.windowElement.querySelector('[sash-id="A"] bw-glass-title'));
+  });
+
+  it('swap: preserves live content nodes (not a rebuild)', () => {
+    const win = mountTwoPanes();
+    const paneA = win.windowElement.querySelector('[sash-id="A"]');
+    const paneB = win.windowElement.querySelector('[sash-id="B"]');
+
+    // Mark the live node inside pane A's content; a real move keeps the same node.
+    const input = document.createElement('input');
+    paneA.querySelector('bw-glass-content').append(input);
+    input.value = 'typed-but-unsaved';
+
+    win.activeDropPaneEl = paneB;
+    win.swapPanes(paneA, paneB);
+
+    // The marked node (and its uncommitted value) followed the content to sash B's pane.
+    const movedInput = win.windowElement.querySelector('[sash-id="B"] bw-glass-content input');
+    expect(movedInput).toBe(input);
+    expect(movedInput.value).toBe('typed-but-unsaved');
+  });
+
+  it('edge-split drop then detach shows the dragged glass content', () => {
+    const win = mountTwoPanes();
+    const paneA = win.windowElement.querySelector('[sash-id="A"]');
+    const paneB = win.windowElement.querySelector('[sash-id="B"]');
+
+    // Arm the drag of glass A, then drop on pane B's right edge via the real handler.
+    paneA
+      .querySelector('bw-glass-header')
+      .dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0 }));
+    win.activeDropPaneEl = paneB;
+    paneB.setAttribute('drop-area', 'right');
+    win.onPaneDrop(new Event('drop'), win.rootSash.getById('B'));
+
+    // The relocated pane holds exactly one glass with A's content.
+    const relocated = win.windowElement.querySelector('[sash-id="A"]');
+    expect(relocated.querySelectorAll('bw-glass').length).toBe(1);
+
+    relocated
+      .querySelector('.bw-glass-action--detach')
+      .dispatchEvent(new Event('click', { bubbles: true }));
+
+    const detached = win.windowElement.querySelector('bw-glass[detached]');
+    expect(detached).toBeTruthy();
+    expect(detached.querySelector('bw-glass-title').textContent).toBe('Title A');
+    expect(detached.querySelector('bw-glass-content').textContent).toContain('Content A');
+  });
+
+  it('detach then attach keeps tabs and content', () => {
+    const win = mountTwoPanes({ title: undefined, tabs: ['One', 'Two'] });
+    const paneA = win.windowElement.querySelector('[sash-id="A"]');
+    expect(paneA.querySelectorAll('.bw-glass-tab').length).toBe(2);
+
+    paneA
+      .querySelector('.bw-glass-action--detach')
+      .dispatchEvent(new Event('click', { bubbles: true }));
+    win.windowElement
+      .querySelector('bw-glass[detached] .bw-glass-action--attach')
+      .dispatchEvent(new Event('click', { bubbles: true }));
+
+    // Tabs and content survive the round-trip (previously dropped to 0 tabs).
+    expect(win.windowElement.querySelectorAll('.bw-glass-tab').length).toBe(2);
+    expect(win.windowElement.querySelector('bw-pane bw-glass-content').textContent).toContain(
+      'Content A'
+    );
+  });
+});

--- a/src/frame/pane-utils.js
+++ b/src/frame/pane-utils.js
@@ -25,7 +25,7 @@ export function updatePaneElement(sash) {
   return paneEl;
 }
 
-function addPaneSashToLeft(targetPaneSash, { size, id }) {
+function addPaneSashToLeft(targetPaneSash, { size, id, store }) {
   const sizeParsed = parseSize(size);
   let newLeftSashWidth = targetPaneSash.width / 2;
 
@@ -37,6 +37,7 @@ function addPaneSashToLeft(targetPaneSash, { size, id }) {
 
   const newLeftSash = new Sash({
     id,
+    store,
     top: targetPaneSash.top,
     left: targetPaneSash.left,
     width: newLeftSashWidth,
@@ -46,6 +47,8 @@ function addPaneSashToLeft(targetPaneSash, { size, id }) {
 
   const newRightSash = new Sash({
     id: targetPaneSash.id,
+    // Continuing pane keeps the target's store so its live glass nodes stay tracked.
+    store: targetPaneSash.store,
     top: targetPaneSash.top,
     left: targetPaneSash.left + newLeftSash.width,
     width: targetPaneSash.width - newLeftSashWidth,
@@ -63,7 +66,7 @@ function addPaneSashToLeft(targetPaneSash, { size, id }) {
   return newLeftSash;
 }
 
-function addPaneSashToRight(targetPaneSash, { size, id }) {
+function addPaneSashToRight(targetPaneSash, { size, id, store }) {
   const sizeParsed = parseSize(size);
   let newRightSashWidth = targetPaneSash.width / 2;
 
@@ -75,6 +78,8 @@ function addPaneSashToRight(targetPaneSash, { size, id }) {
 
   const newLeftSash = new Sash({
     id: targetPaneSash.id,
+    // Continuing pane keeps the target's store so its live glass nodes stay tracked.
+    store: targetPaneSash.store,
     left: targetPaneSash.left,
     top: targetPaneSash.top,
     width: targetPaneSash.width - newRightSashWidth,
@@ -85,6 +90,7 @@ function addPaneSashToRight(targetPaneSash, { size, id }) {
 
   const newRightSash = new Sash({
     id,
+    store,
     left: targetPaneSash.left + newLeftSash.width,
     top: targetPaneSash.top,
     width: newRightSashWidth,
@@ -100,7 +106,7 @@ function addPaneSashToRight(targetPaneSash, { size, id }) {
   return newRightSash;
 }
 
-function addPaneSashToTop(targetPaneSash, { size, id }) {
+function addPaneSashToTop(targetPaneSash, { size, id, store }) {
   const sizeParsed = parseSize(size);
   let newTopSashHeight = targetPaneSash.height / 2;
 
@@ -112,6 +118,7 @@ function addPaneSashToTop(targetPaneSash, { size, id }) {
 
   const newTopSash = new Sash({
     id,
+    store,
     left: targetPaneSash.left,
     top: targetPaneSash.top,
     width: targetPaneSash.width,
@@ -121,6 +128,8 @@ function addPaneSashToTop(targetPaneSash, { size, id }) {
 
   const newBottomSash = new Sash({
     id: targetPaneSash.id,
+    // Continuing pane keeps the target's store so its live glass nodes stay tracked.
+    store: targetPaneSash.store,
     left: targetPaneSash.left,
     top: targetPaneSash.top + newTopSash.height,
     width: targetPaneSash.width,
@@ -137,7 +146,7 @@ function addPaneSashToTop(targetPaneSash, { size, id }) {
   return newTopSash;
 }
 
-function addPaneSashToBottom(targetPaneSash, { size, id }) {
+function addPaneSashToBottom(targetPaneSash, { size, id, store }) {
   const sizeParsed = parseSize(size);
   let newBottomSashHeight = targetPaneSash.height / 2;
 
@@ -149,6 +158,8 @@ function addPaneSashToBottom(targetPaneSash, { size, id }) {
 
   const newTopSash = new Sash({
     id: targetPaneSash.id,
+    // Continuing pane keeps the target's store so its live glass nodes stay tracked.
+    store: targetPaneSash.store,
     top: targetPaneSash.top,
     left: targetPaneSash.left,
     width: targetPaneSash.width,
@@ -159,6 +170,7 @@ function addPaneSashToBottom(targetPaneSash, { size, id }) {
 
   const newBottomSash = new Sash({
     id,
+    store,
     top: targetPaneSash.top + newTopSash.height,
     left: targetPaneSash.left,
     width: targetPaneSash.width,
@@ -177,17 +189,17 @@ function addPaneSashToBottom(targetPaneSash, { size, id }) {
 /**
  * @todo add pane with more Sash props e.g. minWidth, minHeight, etc.
  */
-export function addPaneSash(targetPaneSash, { position, size, id, minWidth, minHeight }) {
+export function addPaneSash(targetPaneSash, { position, size, id, minWidth, minHeight, store }) {
   if (position === Position.Left) {
-    return addPaneSashToLeft(targetPaneSash, { size, id });
+    return addPaneSashToLeft(targetPaneSash, { size, id, store });
   }
   else if (position === Position.Right) {
-    return addPaneSashToRight(targetPaneSash, { size, id });
+    return addPaneSashToRight(targetPaneSash, { size, id, store });
   }
   else if (position === Position.Top) {
-    return addPaneSashToTop(targetPaneSash, { size, id });
+    return addPaneSashToTop(targetPaneSash, { size, id, store });
   }
   else if (position === Position.Bottom) {
-    return addPaneSashToBottom(targetPaneSash, { size, id });
+    return addPaneSashToBottom(targetPaneSash, { size, id, store });
   }
 }

--- a/src/frame/pane.js
+++ b/src/frame/pane.js
@@ -1,4 +1,4 @@
-import { genBrightColor, genId, createDomNode, swapChildNodes } from '../utils.js';
+import { genBrightColor, genId, createDomNode } from '../utils.js';
 import { Position } from '../position.js';
 import { Sash } from '../sash.js';
 import { createPaneElement, addPaneSash, updatePaneElement } from './pane-utils.js';
@@ -46,13 +46,13 @@ export default {
    * @param {'top'|'right'|'bottom'|'left'} position - The position of the new pane relative to the target pane
    * @returns {Sash} - The newly created sash
    */
-  addPane(targetPaneSashId, { position, size, id }) {
+  addPane(targetPaneSashId, { position, size, id, store }) {
     if (!position) throw new Error('[bwin] Position is required when adding pane');
 
     const targetPaneSash = this.rootSash.getById(targetPaneSashId);
     if (!targetPaneSash) throw new Error('[bwin] Parent sash not found when adding pane');
 
-    const newPaneSash = addPaneSash(targetPaneSash, { position, size, id });
+    const newPaneSash = addPaneSash(targetPaneSash, { position, size, id, store });
 
     this.update();
 
@@ -102,17 +102,21 @@ export default {
   },
 
   swapPanes(sourcePaneEl, targetPaneEl) {
-    const sourcePaneSashId = getSashIdFromPane(sourcePaneEl);
-    const targetPaneSashId = getSashIdFromPane(targetPaneEl);
+    const sourceSash = this.rootSash.getById(getSashIdFromPane(sourcePaneEl));
+    const targetSash = this.rootSash.getById(getSashIdFromPane(targetPaneEl));
 
     const sourcePaneCanDrop = sourcePaneEl.getAttribute('can-drop') !== 'false';
     const targetPaneCanDrop = targetPaneEl.getAttribute('can-drop') !== 'false';
 
-    this.rootSash.swapIds(sourcePaneSashId, targetPaneSashId);
-    swapChildNodes(sourcePaneEl, this.activeDropPaneEl);
+    // Swap stores (the single source of truth), then re-render each pane in place.
+    // The first render adopts the other pane's live wrapper, moving it out before the
+    // second render clears it — orphaned nodes stay alive via the swapped store refs.
+    const tempStore = sourceSash.store;
+    sourceSash.store = targetSash.store;
+    targetSash.store = tempStore;
 
-    sourcePaneEl.setAttribute('sash-id', targetPaneSashId);
-    targetPaneEl.setAttribute('sash-id', sourcePaneSashId);
+    this.onPaneCreate(sourcePaneEl, sourceSash);
+    this.onPaneCreate(targetPaneEl, targetSash);
 
     sourcePaneEl.setAttribute('can-drop', targetPaneCanDrop);
     targetPaneEl.setAttribute('can-drop', sourcePaneCanDrop);

--- a/src/sash.js
+++ b/src/sash.js
@@ -54,8 +54,15 @@ export class Sash {
     this.minWidth = minWidth;
     this.minHeight = minHeight;
     this.resizeStrategy = resizeStrategy;
-    // Store non-core props from `ConfigNode` e.g. content, title, tabs, actions, etc
+    // Canonical store of non-core props (content, title, tabs, actions, flags).
+    // After first render `content`/`title` hold the live wrapper nodes, so a move
+    // carries the same DOM — see `setStore`.
     this.store = store;
+  }
+
+  // Single funnel for store writes so updates stay intentional and traceable.
+  setStore(partial) {
+    Object.assign(this.store, partial);
   }
 
   walk(callback) {
@@ -188,19 +195,6 @@ export class Sash {
     }
 
     return null;
-  }
-
-  swapIds(id1, id2) {
-    const sash1 = this.getById(id1);
-    const sash2 = this.getById(id2);
-
-    if (!sash1 || !sash2) {
-      throw new Error('[bwin] Sash not found when swapping IDs');
-    }
-
-    const tempId = sash1.id;
-    sash1.id = sash2.id;
-    sash2.id = tempId;
   }
 
   // Get all ids of self and descendants


### PR DESCRIPTION
## Problem

`Sash.store` held a glass's non-core props (`content`, `title`, `tabs`, `actions`, flags) but was written **once at construction** and never updated. `Glass` also materialized that data into the DOM, so two copies existed — and the move operations read different ones:

- **Initial render / re-render** read `sash.store`
- **Detach / attach / swap** read the **DOM**

Nothing wrote back, so the two drifted. Three concrete failures (all reproduced before the change):

1. **Swap left `store` stale** — after `swapPanes`, `sashA.store.title` still said "Title A" while its DOM showed "Title B"; any later re-render from `store` reverted content.
2. **Detach→attach dropped everything but content+title** — tabs went 2 → 0, custom `actions`/`droppable`/`resizable` were lost, and title was degraded to `textContent`.
3. **Edge-split drop then detach** picked up the empty placeholder glass `addPane` seeds.

## Approach

`store` becomes the single source of truth. After first render, `store.content` / `store.title` hold the **live** `bw-glass-content` / `bw-glass-title` wrapper nodes. Every move reads and writes `store`; the DOM is rebuilt from it, **adopting the same live nodes** — so in-progress input, scroll position, and listeners survive a move.

## Changes

- **`sash.js`** — add `setStore(partial)` to funnel writes; remove now-unused `swapIds`.
- **`glass/class.js`** — `build()` adopts an existing wrapper element (new `buildWrapper` helper) instead of always creating one.
- **`binary-window.js`** — `onPaneCreate` writes the live wrappers back to `store`; `addPane` seeds the new sash's `store` and renders via `onPaneCreate` (eliminates the placeholder double-glass).
- **`pane-utils.js` / `pane.js`** — thread `store` through `addPane` → `addPaneSash`; the continuing pane inherits the target's `store`.
- **`pane.js`** — `swapPanes` swaps `store` and re-renders both panes (drops the id-swap, `swapChildNodes`, and a latent `this.activeDropPaneEl` misreference).
- **`glass/drag.js`** — edge drop captures the source `store` and re-renders via `addPane`.
- **`action.detach.js` / `action.attach.js`** — detach reads `sash.store` and stashes the full store on the element (`bwStore`); attach restores it, so tabs/actions/flags come back.

## Tests

New `src/binary-window/store-sot.test.js` (4 tests):

- swap keeps `store` and DOM in sync
- **live-node preservation** — an uncommitted `<input>` value survives a swap (same node moved, not rebuilt)
- edge-split drop → detach shows the dragged glass's content (one glass, not the placeholder)
- detach → attach keeps tabs (the 2 → 0 regression) and content

Full suite: **28 passed** (24 existing + 4 new). `dev/` pages unaffected.

## Notes

- `swapChildNodes` and `extractChildNodes` in `src/utils.js` are now internally unused (still exported; not re-exported via `index.js`). Left in place — removing exported helpers is out of scope for this refactor.
- Branched off `origin/main`; this root fix supersedes the earlier `replaceChildren` patch for failure #3.
