### PR TITLE
docs: document sash.store one-way-seed intent and tech debt

### DIFF
--- a/src/sash.js
+++ b/src/sash.js
@@ -54,7 +54,20 @@ export class Sash {
     this.minWidth = minWidth;
     this.minHeight = minHeight;
     this.resizeStrategy = resizeStrategy;
-    // Store non-core props from `ConfigNode` e.g. content, title, tabs, actions, etc
+    /*
+     * Stores non-core props from `ConfigNode` e.g. content, title, tabs, actions, event
+     * handlers (e.g. `onDrop`).
+     *
+     * RATIONAL: `store` is meant as a one-way seed — it carries these from the
+     * top-level API into pane/glass construction, then should stop. It is NOT a live
+     * model: moves like attach/detach/swap exchange data through the DOM, not here,
+     * because the DOM is visible and easy to debug in the browser.
+     *
+     * TECH DEBT: not yet a pure seed — `onDrop` (droppable.js) is read at drop time
+     * and `resizable` (muntin.js) when a pane is split, both long after construction.
+     * Until those are moved onto the DOM/closures at build time, `store` can't be
+     * cleared in `onPaneCreate` without breaking them.
+     */
     this.store = store;
   }
 


### PR DESCRIPTION
## What

Expands the comment on `Sash.store` (`src/sash.js`) from a one-liner into a `/* */` block documenting its **intended design** and a known **tech-debt gap**.

## Why

`store` is *meant* to be a one-way construction seed — config props flow from the top-level API into pane/glass construction, then stop. Data exchange for moves (attach/detach/swap) happens at the DOM layer, which is visible and debuggable in the browser.

But the code doesn't fully honor that yet: `onDrop` (`droppable.js`) is read at drop time and `resizable` (`muntin.js`) when a pane is split — both long after construction. So anyone who tries to clear `store` in `onPaneCreate` (a reasonable thing to attempt) would silently break per-pane `onDrop` callbacks and `resizable`-on-split.

The comment now records:
- **RATIONAL** — the one-way-seed / DOM-is-the-exchange-layer intent.
- **TECH DEBT** — the two late readers, and the concrete consequence: `store` can't be cleared until `onDrop`/`resizable` are moved onto the DOM/closures at build time.

## Scope

Comment only — no behavior change.
