### PR TITLE
fix: blank glass on restore-minimized via addPane withGlass flag

### DIFF
--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -41,15 +41,6 @@ This complements [`ARCHITECTURE.md`](./ARCHITECTURE.md) (how things work) and [`
 
 ---
 
-## [medium] `addPane` seeds an empty placeholder glass (drop must `replaceChildren`)
-
-- **Where:** `src/binary-window/binary-window.js` (`addPane`), `src/binary-window/glass/drag.js` (`onPaneDrop`)
-- **What:** `BinaryWindow.addPane` always creates a new pane pre-seeded with its own empty placeholder `Glass`. Callers that want to place an existing glass into the new pane must `replaceChildren(...)`, **not** `append(...)` — an append leaves two glasses (empty placeholder first), and a later detach's `querySelector('bw-glass-content')` then grabs the empty one, producing a blank detached glass.
-- **Impact:** A non-obvious sequencing trap; this exact mistake has produced "blank glass" bugs (the kind of root cause that may underlie a GitHub issue). The placeholder is wasted work whenever the caller is about to replace it.
-- **Fix direction:** let `addPane` optionally skip seeding the placeholder (e.g. accept a glass/content to mount, or a `seedGlass: false` flag), so the drop path doesn't create-then-discard a glass.
-
----
-
 ## [medium] `react-bwin` depends on bwin internals (no stable public surface)
 
 - **Where:** cross-repo — `../react-bwin`; documented in [`context/react-bwin-integration.md`](./context/react-bwin-integration.md)

--- a/src/binary-window/binary-window.js
+++ b/src/binary-window/binary-window.js
@@ -44,17 +44,22 @@ export class BinaryWindow extends Frame {
   }
 
   /**
-   * Add a pane with glass into the target pane.
+   * Add a pane into the target pane, optionally seeded with a glass built from
+   * `glassProps`. Callers that mount their own existing glass (drag, restore)
+   * pass `withGlass: false` to get a bare pane without glass.
    *
    * @param {string} targetPaneSashId - The Sash ID of the target pane
    * @param {Object} props - The pane and glass properties grouped together
+   * @param {boolean} [props.withGlass=true] - Whether to seed the pane with a glass
    * @returns {Sash} - The newly created Sash
    */
   addPane(targetPaneSashId, props) {
-    const { position, size, id, ...glassProps } = props;
+    const { position, size, id, withGlass = true, ...glassProps } = props;
     const paneSash = super.addPane(targetPaneSashId, { position, size, id });
-    const glass = new Glass({ ...glassProps, sash: paneSash, binaryWindow: this });
-    paneSash.domNode.append(glass.domNode);
+    if (withGlass) {
+      const glass = new Glass({ ...glassProps, sash: paneSash, binaryWindow: this });
+      paneSash.domNode.append(glass.domNode);
+    }
     return paneSash;
   }
 

--- a/src/binary-window/glass/action.js
+++ b/src/binary-window/glass/action.js
@@ -57,6 +57,7 @@ export default {
         id: originalSashId,
         position: newPosition,
         size: newSize,
+        withGlass: false,
       });
       newSashPane.domNode.append(minimizedGlassEl.bwGlassElement);
     }

--- a/src/binary-window/glass/drag.js
+++ b/src/binary-window/glass/drag.js
@@ -23,10 +23,8 @@ export default {
       const oldSashId = getSashIdFromPane(activeDragGlassEl);
       this.removePane(oldSashId);
 
-      const newPaneSash = this.addPane(sash.id, { position: dropArea, id: oldSashId });
-      // `addPane` seeds the pane with an empty placeholder glass; replace it with
-      // the dragged glass so the pane holds exactly one (the real) glass.
-      newPaneSash.domNode.replaceChildren(activeDragGlassEl);
+      const newPaneSash = this.addPane(sash.id, { position: dropArea, id: oldSashId, withGlass: false });
+      newPaneSash.domNode.append(activeDragGlassEl);
     }
   },
 


### PR DESCRIPTION
Closes #61

## What

`BinaryWindow.addPane` always seeded a placeholder `Glass` built from its `glassProps`, even for callers that already hold a real glass element and only need the pane. This conflated two intents in one signature and forced those callers to defeat the placeholder.

The **restore-minimized** path (`glass/action.js`) used `append` (not `replaceChildren`), leaving **two** `bw-glass` children in the pane — empty placeholder first, restored glass second. A later detach reads `querySelector('bw-glass-content')`, which returns the *first* (empty) match → a blank glass (obvious when maximized). This is the same class of bug as #56 (edge-split drop).

## Change

- Add a `withGlass` flag to `addPane` (defaults to `true`). When false, `addPane` allocates a bare pane without constructing a glass.
- `glass/drag.js` and `glass/action.js` (the bring-your-own-glass callers) pass `withGlass: false` and `append` their own glass into the now-empty pane.
- Build-a-glass callers (`detached-glass/action.attach.js`, the `dev/` add-pane page) are unchanged — `withGlass` defaults true, so the seeded glass and the react-bwin `addPane` content workaround keep working.
- Removed the corresponding `docs/TECH_DEBT.md` entry (per its "delete when fixed" convention).

## Notes

- `drag.js` previously used `replaceChildren` to overwrite the placeholder; with no placeholder, a plain `append` into the fresh empty pane is equivalent and keeps #56 fixed.
- Not yet verified live — recommend exercising drag-out → edge-drop → maximize and restore-minimized → detach.