### PR TITLE
fix: thread minWidth/minHeight through addPane

### DIFF
--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -83,6 +83,5 @@ Open questions parked in code comments — not yet decided:
 
 - **`src/sash.js`** — what should happen when `minWidth`/`minHeight` is set larger than the sash's own width/height? (currently undefined behavior)
 - **`src/frame/frame.js`** — should the frame resize immediately when `fitContainer` toggles? (a `fit()` method now exists, so this is partly addressed)
-- **`src/frame/pane-utils.js`** — `addPaneSash` ignores `minWidth`/`minHeight` (and other Sash props); a pane added at runtime can't carry min-size constraints.
 
-**Impact:** edge-case behavior is unspecified; `addPaneSash`'s gap means runtime-added panes differ from config-built ones. **Fix direction:** decide the min-vs-own-size rule and thread the remaining Sash props through `addPaneSash`.
+**Impact:** edge-case behavior is unspecified. **Fix direction:** decide the min-vs-own-size rule.

--- a/src/binary-window/binary-window.js
+++ b/src/binary-window/binary-window.js
@@ -54,8 +54,8 @@ export class BinaryWindow extends Frame {
    * @returns {Sash} - The newly created Sash
    */
   addPane(targetPaneSashId, props) {
-    const { position, size, id, withGlass = true, ...glassProps } = props;
-    const paneSash = super.addPane(targetPaneSashId, { position, size, id });
+    const { position, size, id, minWidth, minHeight, withGlass = true, ...glassProps } = props;
+    const paneSash = super.addPane(targetPaneSashId, { position, size, id, minWidth, minHeight });
     if (withGlass) {
       const glass = new Glass({ ...glassProps, sash: paneSash, binaryWindow: this });
       paneSash.domNode.append(glass.domNode);

--- a/src/frame/pane-utils.js
+++ b/src/frame/pane-utils.js
@@ -25,7 +25,7 @@ export function updatePaneElement(sash) {
   return paneEl;
 }
 
-function addPaneSashToLeft(targetPaneSash, { size, id }) {
+function addPaneSashToLeft(targetPaneSash, { size, id, minWidth, minHeight }) {
   const sizeParsed = parseSize(size);
   let newLeftSashWidth = targetPaneSash.width / 2;
 
@@ -41,6 +41,8 @@ function addPaneSashToLeft(targetPaneSash, { size, id }) {
     left: targetPaneSash.left,
     width: newLeftSashWidth,
     height: targetPaneSash.height,
+    minWidth,
+    minHeight,
     position: Position.Left,
   });
 
@@ -63,7 +65,7 @@ function addPaneSashToLeft(targetPaneSash, { size, id }) {
   return newLeftSash;
 }
 
-function addPaneSashToRight(targetPaneSash, { size, id }) {
+function addPaneSashToRight(targetPaneSash, { size, id, minWidth, minHeight }) {
   const sizeParsed = parseSize(size);
   let newRightSashWidth = targetPaneSash.width / 2;
 
@@ -89,6 +91,8 @@ function addPaneSashToRight(targetPaneSash, { size, id }) {
     top: targetPaneSash.top,
     width: newRightSashWidth,
     height: targetPaneSash.height,
+    minWidth,
+    minHeight,
     position: Position.Right,
   });
 
@@ -100,7 +104,7 @@ function addPaneSashToRight(targetPaneSash, { size, id }) {
   return newRightSash;
 }
 
-function addPaneSashToTop(targetPaneSash, { size, id }) {
+function addPaneSashToTop(targetPaneSash, { size, id, minWidth, minHeight }) {
   const sizeParsed = parseSize(size);
   let newTopSashHeight = targetPaneSash.height / 2;
 
@@ -116,6 +120,8 @@ function addPaneSashToTop(targetPaneSash, { size, id }) {
     top: targetPaneSash.top,
     width: targetPaneSash.width,
     height: newTopSashHeight,
+    minWidth,
+    minHeight,
     position: Position.Top,
   });
 
@@ -137,7 +143,7 @@ function addPaneSashToTop(targetPaneSash, { size, id }) {
   return newTopSash;
 }
 
-function addPaneSashToBottom(targetPaneSash, { size, id }) {
+function addPaneSashToBottom(targetPaneSash, { size, id, minWidth, minHeight }) {
   const sizeParsed = parseSize(size);
   let newBottomSashHeight = targetPaneSash.height / 2;
 
@@ -163,6 +169,8 @@ function addPaneSashToBottom(targetPaneSash, { size, id }) {
     left: targetPaneSash.left,
     width: targetPaneSash.width,
     height: newBottomSashHeight,
+    minWidth,
+    minHeight,
     position: Position.Bottom,
   });
 
@@ -174,20 +182,17 @@ function addPaneSashToBottom(targetPaneSash, { size, id }) {
   return newBottomSash;
 }
 
-/**
- * @todo add pane with more Sash props e.g. minWidth, minHeight, etc.
- */
 export function addPaneSash(targetPaneSash, { position, size, id, minWidth, minHeight }) {
   if (position === Position.Left) {
-    return addPaneSashToLeft(targetPaneSash, { size, id });
+    return addPaneSashToLeft(targetPaneSash, { size, id, minWidth, minHeight });
   }
   else if (position === Position.Right) {
-    return addPaneSashToRight(targetPaneSash, { size, id });
+    return addPaneSashToRight(targetPaneSash, { size, id, minWidth, minHeight });
   }
   else if (position === Position.Top) {
-    return addPaneSashToTop(targetPaneSash, { size, id });
+    return addPaneSashToTop(targetPaneSash, { size, id, minWidth, minHeight });
   }
   else if (position === Position.Bottom) {
-    return addPaneSashToBottom(targetPaneSash, { size, id });
+    return addPaneSashToBottom(targetPaneSash, { size, id, minWidth, minHeight });
   }
 }

--- a/src/frame/pane-utils.test.js
+++ b/src/frame/pane-utils.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { addPaneSash } from './pane-utils';
+import { Sash, DEFAULTS } from '../sash';
+import { Position } from '../position';
+
+function makeTargetSash() {
+  return new Sash({
+    top: 0,
+    left: 0,
+    width: 800,
+    height: 600,
+    position: Position.Root,
+  });
+}
+
+describe('addPaneSash min-size threading', () => {
+  for (const position of [Position.Left, Position.Right, Position.Top, Position.Bottom]) {
+    it(`carries minWidth/minHeight onto the new ${position} pane sash`, () => {
+      const target = makeTargetSash();
+
+      const newSash = addPaneSash(target, {
+        position,
+        id: 'new-pane',
+        minWidth: 222,
+        minHeight: 333,
+      });
+
+      expect(newSash.minWidth).toBe(222);
+      expect(newSash.minHeight).toBe(333);
+    });
+  }
+
+  it('falls back to Sash defaults when min-size props are omitted', () => {
+    const target = makeTargetSash();
+
+    const newSash = addPaneSash(target, { position: Position.Left, id: 'new-pane' });
+
+    expect(newSash.minWidth).toBe(DEFAULTS.minWidth);
+    expect(newSash.minHeight).toBe(DEFAULTS.minHeight);
+  });
+
+  it('leaves the retained sibling sash at its own defaults', () => {
+    const target = makeTargetSash();
+
+    addPaneSash(target, {
+      position: Position.Left,
+      id: 'new-pane',
+      minWidth: 222,
+      minHeight: 333,
+    });
+
+    // The new pane is the Left child; the original content moves to the sibling
+    const sibling = target.children.find((child) => child.id !== 'new-pane');
+    expect(sibling.minWidth).toBe(DEFAULTS.minWidth);
+    expect(sibling.minHeight).toBe(DEFAULTS.minHeight);
+  });
+});

--- a/src/frame/pane.js
+++ b/src/frame/pane.js
@@ -46,13 +46,13 @@ export default {
    * @param {'top'|'right'|'bottom'|'left'} position - The position of the new pane relative to the target pane
    * @returns {Sash} - The newly created sash
    */
-  addPane(targetPaneSashId, { position, size, id }) {
+  addPane(targetPaneSashId, { position, size, id, minWidth, minHeight }) {
     if (!position) throw new Error('[bwin] Position is required when adding pane');
 
     const targetPaneSash = this.rootSash.getById(targetPaneSashId);
     if (!targetPaneSash) throw new Error('[bwin] Parent sash not found when adding pane');
 
-    const newPaneSash = addPaneSash(targetPaneSash, { position, size, id });
+    const newPaneSash = addPaneSash(targetPaneSash, { position, size, id, minWidth, minHeight });
 
     this.update();
 


### PR DESCRIPTION
## What

`addPaneSash` declared `minWidth`/`minHeight` in its signature but never passed them to the inner split helpers (`addPaneSashTo{Left,Right,Top,Bottom}`), so a pane added at runtime couldn't carry min-size constraints and silently differed from config-built panes.

This plumbs both props through the full call chain:

- `src/frame/pane-utils.js` — all four split helpers accept and forward `minWidth`/`minHeight` onto the new `Sash`; dispatcher threads them; removed the resolved `@todo`.
- `src/frame/pane.js` — `Frame.addPane` forwards the props.
- `src/binary-window/binary-window.js` — `BinaryWindow.addPane` destructures them out before `...glassProps` so they reach `super.addPane` rather than leaking into glass construction.

## Why

Fixes the resolved bullet of the `[low]` "Unresolved design questions" tech-debt entry — updated `docs/TECH_DEBT.md` accordingly (the remaining `sash.js` and `frame.js` questions stay open).

## Tests

New `src/frame/pane-utils.test.js`:
- all four directions carry `minWidth`/`minHeight` onto the new pane sash
- omitting the props falls back to `Sash` `DEFAULTS`
- the retained sibling sash keeps its own defaults

Full suite green (30/30).