### PR TITLE
fix: move glass background to glass-content so tab bar isn't painted

### DIFF
--- a/src/css/glass.css
+++ b/src/css/glass.css
@@ -51,7 +51,6 @@ bw-glass {
   flex-direction: column;
   border: 1px solid var(--bw-glass-border-color);
   border-radius: var(--bw-glass-border-radius);
-  background-color: white;
   font-family: var(--bw-font-family);
   font-size: var(--bw-font-size);
   box-sizing: border-box;
@@ -193,4 +192,7 @@ bw-glass-content {
   box-sizing: border-box;
   overflow: auto;
   flex-grow: 1;
+  background-color: white;
+  border-bottom-left-radius: var(--bw-glass-border-radius);
+  border-bottom-right-radius: var(--bw-glass-border-radius);
 }

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -42,9 +42,9 @@ bw-window[theme='dark'] {
     background-color: hsl(0 0% 14%);
   }
 
-  bw-glass {
-    background-color: hsl(0 0% 16%);
+  bw-glass-content {
     color: hsl(0 0% 90%);
+    background-color: hsl(0 0% 16%);
   }
 
   .bw-glass-tab:hover,


### PR DESCRIPTION
## Summary

Paint the glass background (white in light theme, `hsl(0 0% 16%)` in dark) and the bottom corner radii on `bw-glass-content` instead of `bw-glass`, so the background no longer bleeds behind the tab bar.

## Changes

- `src/css/glass.css` — move `background-color: white` off `bw-glass`; add it plus bottom-left/right `border-radius` to `bw-glass-content`.
- `src/css/vars.css` — in the dark theme, move `background-color` and `color` from `bw-glass` to `bw-glass-content`.