### PR TITLE
ci: auto-publish dev release to npm on merged PR

### DIFF
--- a/.github/workflows/dev-publish.yml
+++ b/.github/workflows/dev-publish.yml
@@ -1,0 +1,56 @@
+name: Publish dev release
+
+# Auto-publishes an ephemeral dev build to npm (dist-tag `dev`) on every merged PR to main.
+# Version is computed at publish time as <next-patch>-dev-<shortsha> and never written back to
+# the repo, so there is no version-bump commit and no re-trigger loop.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  dev-publish:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 11
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+
+      - name: Compute ephemeral dev version
+        id: version
+        run: |
+          base="$(node -p "require('./package.json').version")"
+          # Next patch: split on '.', bump the last field. No semver dependency needed.
+          next="$(node -p "const [a,b,c]=require('./package.json').version.split('.'); [a,b,Number(c)+1].join('.')")"
+          sha="$(git rev-parse --short HEAD)"
+          devver="${next}-dev-${sha}"
+          # Edits the runner's copy only; --no-git-tag-version makes no commit and no tag.
+          npm version --no-git-tag-version "$devver"
+          echo "devver=$devver" >> "$GITHUB_OUTPUT"
+          echo "Publishing dev release \`$devver\` (base $base)" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build package
+        run: pnpm build
+
+      - name: Publish to npm
+        run: pnpm publish --no-git-checks --access public --tag dev


### PR DESCRIPTION
## What

Adds `.github/workflows/dev-publish.yml`: on every PR **merged** into `main`, automatically publish a dev build to npm under the `dev` dist-tag.

## How

- **Trigger:** `pull_request: closed` on `main`, guarded by `if: github.event.pull_request.merged == true` (ignores closed-without-merge).
- **Ephemeral version:** reads `package.json`, auto-increments the patch field, appends `-dev-<shortsha>` → e.g. `0.4.5-dev-9e70cf0`. Applied with `npm version --no-git-tag-version`, so it edits only the runner's copy — **no commit, no tag, nothing pushed back to main**. This is what avoids any version-bump-PR / re-trigger loop.
- **Publish:** `pnpm publish --no-git-checks --access public --tag dev` via OIDC. Runs **unattended** (no `PUBLISH` environment gate, by design). `latest` is never touched.

## Notes

- Mirrors the existing `publish.yml` step structure; that manual stable-release workflow is unchanged.
- Next-patch assumes the next release is a patch; if a release is minor/major, the dev label lags until `package.json` is bumped on main — expected.
- **Requires** npm trusted-publishing (OIDC) to accept this workflow *without* the `PUBLISH` environment. If the npm trusted-publisher config is scoped to that environment, it must be widened to cover this workflow.