### PR TITLE
feat: updatePane API — layout at frame layer + glass title/content

### DIFF
--- a/dev/features/bwin-update-pane.html
+++ b/dev/features/bwin-update-pane.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script type="module" src="./bwin-update-pane.js"></script>
+  </head>
+  <body>
+    <main>
+      <h2>BinaryWindow - update pane (glass)</h2>
+      <p>Panes: <code>a</code>, <code>b</code>, <code>c</code>.</p>
+
+      <label>Sash ID <input id="sash-id" type="text" value="a" placeholder="e.g. a" /></label>
+      <fieldset style="display: inline-block">
+        <legend>position</legend>
+        <label><input type="radio" name="sash-position" value="" checked />(unchanged)</label>
+        <label><input type="radio" name="sash-position" value="left" />left</label>
+        <label><input type="radio" name="sash-position" value="right" />right</label>
+        <label><input type="radio" name="sash-position" value="top" />top</label>
+        <label><input type="radio" name="sash-position" value="bottom" />bottom</label>
+      </fieldset>
+      <label>size <input id="size" type="text" placeholder="e.g. 0.3 or 200px" /></label>
+      <br />
+      <label
+        >title <input id="title" type="text" placeholder="e.g. <mark>Updated title</mark>"
+      /></label>
+      <label
+        >content <input id="content" type="text" placeholder="e.g. <b>Updated content</b>"
+      /></label>
+      <button id="update-pane">Update pane</button>
+
+      <section id="container" style="height: 60vh"></section>
+    </main>
+  </body>
+</html>

--- a/dev/features/bwin-update-pane.js
+++ b/dev/features/bwin-update-pane.js
@@ -1,0 +1,37 @@
+import { BinaryWindow } from '../../src';
+
+const settings = {
+  width: 444,
+  height: 333,
+  children: [
+    { position: 'left', size: '40%', id: 'a', title: 'a', content: 'Pane a' },
+    {
+      children: [
+        { position: 'top', size: '30%', id: 'b', title: 'b', content: 'Pane b' },
+        { position: 'bottom', size: '70%', id: 'c', title: 'c', content: 'Pane c' },
+      ],
+    },
+  ],
+};
+
+const bwin = new BinaryWindow(settings);
+bwin.mount(document.querySelector('#container'));
+
+document.querySelector('#update-pane').addEventListener('click', () => {
+  const id = document.querySelector('#sash-id').value.trim();
+  const position = document.querySelector('input[name="sash-position"]:checked').value;
+  const size = document.querySelector('#size').value.trim();
+  const title = document.querySelector('#title').value;
+  const content = document.querySelector('#content').value;
+
+  // Only pass fields the user actually filled in.
+  const props = { id };
+  if (position) props.position = position;
+  if (size) props.size = size;
+  if (title) props.title = title;
+  if (content) props.content = content;
+
+  bwin.updatePane(props);
+});
+
+window.bwin = bwin;

--- a/dev/features/update-pane.html
+++ b/dev/features/update-pane.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script type="module" src="./update-pane.js"></script>
+  </head>
+  <body>
+    <main>
+      <h2>Frame - update pane</h2>
+      <p>
+        Left/right window panes: <code>lr-a</code>, <code>lr-b</code>. Top/bottom window panes:
+        <code>tb-a</code>, <code>tb-b</code>.
+      </p>
+
+      <label>Sash ID <input id="sash-id" type="text" placeholder="e.g. lr-a" /></label>
+      <fieldset style="display: inline-block">
+        <legend>position</legend>
+        <label><input type="radio" name="sash-position" value="" checked />(unchanged)</label>
+        <label><input type="radio" name="sash-position" value="left" />left</label>
+        <label><input type="radio" name="sash-position" value="right" />right</label>
+        <label><input type="radio" name="sash-position" value="top" />top</label>
+        <label><input type="radio" name="sash-position" value="bottom" />bottom</label>
+      </fieldset>
+      <br />
+      <label>size <input id="size" type="text" placeholder="e.g. 0.3 or 200px" /></label>
+      <label>min width <input id="min-width" type="number" placeholder="px" /></label>
+      <label>min height <input id="min-height" type="number" placeholder="px" /></label>
+      <button id="update-pane">Update pane</button>
+
+      <h3>Left / right</h3>
+      <section id="container-lr" style="margin-bottom: 350px"></section>
+      <h3>Top / bottom</h3>
+      <section id="container-tb"></section>
+    </main>
+  </body>
+</html>

--- a/dev/features/update-pane.js
+++ b/dev/features/update-pane.js
@@ -39,13 +39,13 @@ document.querySelector('#update-pane').addEventListener('click', () => {
   }
 
   // Only pass fields the user actually filled in.
-  const props = { id };
+  const props = {};
   if (position) props.position = position;
   if (size) props.size = size;
   if (minWidth) props.minWidth = Number(minWidth);
   if (minHeight) props.minHeight = Number(minHeight);
 
-  frame.updatePane(props);
+  frame.updatePane(id, props);
 });
 
 window.lrFrame = lrFrame;

--- a/dev/features/update-pane.js
+++ b/dev/features/update-pane.js
@@ -1,0 +1,52 @@
+import { Frame } from '../../src';
+
+const lrFrame = new Frame({
+  width: 600,
+  height: 300,
+  children: [
+    { id: 'lr-a', position: 'left', size: 0.5, content: 'Left/right pane A (lr-a)' },
+    { id: 'lr-b', content: 'Left/right pane B (lr-b)' },
+  ],
+});
+lrFrame.mount(document.querySelector('#container-lr'));
+
+const tbFrame = new Frame({
+  width: 600,
+  height: 300,
+  children: [
+    { id: 'tb-a', position: 'top', size: 0.5, content: 'Top/bottom pane A (tb-a)' },
+    { id: 'tb-b', content: 'Top/bottom pane B (tb-b)' },
+  ],
+});
+tbFrame.mount(document.querySelector('#container-tb'));
+
+// Route a sash id to the frame that owns it.
+function getFrameForSashId(id) {
+  return lrFrame.rootSash.getById(id) ? lrFrame : tbFrame.rootSash.getById(id) ? tbFrame : null;
+}
+
+document.querySelector('#update-pane').addEventListener('click', () => {
+  const id = document.querySelector('#sash-id').value.trim();
+  const position = document.querySelector('input[name="sash-position"]:checked').value;
+  const size = document.querySelector('#size').value.trim();
+  const minWidth = document.querySelector('#min-width').value.trim();
+  const minHeight = document.querySelector('#min-height').value.trim();
+
+  const frame = getFrameForSashId(id);
+  if (!frame) {
+    console.warn(`[update-pane] No pane found with id "${id}"`);
+    return;
+  }
+
+  // Only pass fields the user actually filled in.
+  const props = { id };
+  if (position) props.position = position;
+  if (size) props.size = size;
+  if (minWidth) props.minWidth = Number(minWidth);
+  if (minHeight) props.minHeight = Number(minHeight);
+
+  frame.updatePane(props);
+});
+
+window.lrFrame = lrFrame;
+window.tbFrame = tbFrame;

--- a/src/binary-window/binary-window.js
+++ b/src/binary-window/binary-window.js
@@ -9,6 +9,7 @@ import detachedGlassModule, {
 } from './detached-glass';
 import { detachedGlassManager } from './detached-glass/manager';
 import { normActions } from './utils';
+import { updateGlass } from './glass/utils';
 
 export class BinaryWindow extends Frame {
   sillElement = null;
@@ -69,20 +70,21 @@ export class BinaryWindow extends Frame {
     return paneSash;
   }
 
-  /**
-   * Set the window theme.
-   *
-   * @param {string} theme - The theme name, set as the `theme` attribute on the `bw-window` element
-   */
-  setTheme(theme) {
-    if (!theme) {
-      this.theme = '';
-      this.windowElement.removeAttribute('theme');
-      return;
+  // TODO: support updating glass `actions` (rebuild the action bar/menu in place).
+  updatePane({ position, size, id, minWidth, minHeight, title, content }) {
+    const sash = this.rootSash.getById(id);
+    if (!sash) throw new Error(`[bwin] No sash found with id ${id} when updating pane`);
+
+    if (position || size || minWidth || minHeight) {
+      super.updatePane(id, { position, size, minWidth, minHeight });
     }
 
-    this.theme = theme;
-    this.windowElement.setAttribute('theme', theme);
+    if (title || content) {
+      const glassEl = sash.domNode.querySelector('bw-glass');
+      if (!glassEl)
+        throw new Error(`[bwin] No glass found in pane with id ${id} when updating pane`);
+      updateGlass(glassEl, { title, content });
+    }
   }
 
   removePane(paneSashId) {
@@ -98,6 +100,22 @@ export class BinaryWindow extends Frame {
     if (potEl) {
       potEl.remove();
     }
+  }
+
+  /**
+   * Set the window theme.
+   *
+   * @param {string} theme - The theme name, set as the `theme` attribute on the `bw-window` element
+   */
+  setTheme(theme) {
+    if (!theme) {
+      this.theme = '';
+      this.windowElement.removeAttribute('theme');
+      return;
+    }
+
+    this.theme = theme;
+    this.windowElement.setAttribute('theme', theme);
   }
 
   /**

--- a/src/binary-window/glass/utils.js
+++ b/src/binary-window/glass/utils.js
@@ -1,3 +1,5 @@
+import { createDomNode } from '@/utils';
+
 // Moves the action menu, title/tabs and content children from one glass to
 // another, keeping the target's own header actions. Used when detaching/attaching.
 export function transferGlass(sourceGlassElement, targetGlassElement) {
@@ -37,4 +39,32 @@ export function transferGlass(sourceGlassElement, targetGlassElement) {
   const sourceContentEl = sourceGlassElement.querySelector('bw-glass-content');
   const targetContentEl = targetGlassElement.querySelector('bw-glass-content');
   targetContentEl.append(...sourceContentEl.childNodes);
+}
+
+export function updateGlassTitle(glassElement, title) {
+  const titleEl = glassElement.querySelector('bw-glass-title');
+  if (!titleEl) return;
+
+  titleEl.replaceChildren();
+  const titleNode = createDomNode(title);
+  if (titleNode) titleEl.append(titleNode);
+}
+
+export function updateGlassContent(glassElement, content) {
+  const contentEl = glassElement.querySelector('bw-glass-content');
+  if (!contentEl) return;
+
+  contentEl.replaceChildren();
+  const contentNode = createDomNode(content);
+  if (contentNode) contentEl.append(contentNode);
+}
+
+// Update an existing glass's header title and/or content in place.
+export function updateGlass(glassElement, { title, content }) {
+  if (title != null) {
+    updateGlassTitle(glassElement, title);
+  }
+  if (content != null) {
+    updateGlassContent(glassElement, content);
+  }
 }

--- a/src/frame/main.js
+++ b/src/frame/main.js
@@ -1,3 +1,5 @@
+import { updatePaneElement } from './pane-utils.js';
+
 export default {
   createWindow({ theme } = {}) {
     const windowEl = document.createElement('bw-window');
@@ -66,7 +68,7 @@ export default {
           this.windowElement.prepend(sash.domNode);
         }
         else {
-          this.updatePane(sash);
+          updatePaneElement(sash);
           this.onPaneUpdate(sash.domNode, sash);
         }
       }

--- a/src/frame/pane-utils.js
+++ b/src/frame/pane-utils.js
@@ -1,5 +1,5 @@
 import { parseSize, genId } from '../utils.js';
-import { Position } from '../position.js';
+import { Position, getOppositePosition } from '../position.js';
 import { Sash } from '../sash.js';
 
 export function createPaneElement(sash) {
@@ -23,6 +23,122 @@ export function updatePaneElement(sash) {
   paneEl.setAttribute('position', sash.position);
 
   return paneEl;
+}
+
+// Re-place a pane at `position`, keeping its current relative size. Same-axis
+// change swaps it with its sibling; cross-axis change reorients the split.
+export function updatePanePosition(sash, position) {
+  const parent = sash.parent;
+  if (!parent) return;
+
+  const sibling = parent.getChildSiblingById(sash.id);
+  if (!sibling) return;
+
+  const parentRect = {
+    top: parent.top,
+    left: parent.left,
+    width: parent.width,
+    height: parent.height,
+  };
+
+  const fraction = sash.getRelativeSize();
+  const wasLeftRight = parent.isLeftRightSplit();
+  const willBeLeftRight = position === Position.Left || position === Position.Right;
+  const axisChanged = wasLeftRight !== willBeLeftRight;
+
+  sash.position = position;
+  sibling.position = getOppositePosition(position);
+
+  if (position === Position.Left || position === Position.Right) {
+    const sashWidth = parentRect.width * fraction;
+
+    sash.top = parentRect.top;
+    sibling.top = parentRect.top;
+    sash.height = parentRect.height;
+    sibling.height = parentRect.height;
+    sash.width = sashWidth;
+    sibling.width = parentRect.width - sashWidth;
+
+    if (position === Position.Left) {
+      sash.left = parentRect.left;
+      sibling.left = parentRect.left + sashWidth;
+    }
+    else {
+      sibling.left = parentRect.left;
+      sash.left = parentRect.left + sibling.width;
+    }
+  }
+  else {
+    const sashHeight = parentRect.height * fraction;
+
+    sash.left = parentRect.left;
+    sibling.left = parentRect.left;
+    sash.width = parentRect.width;
+    sibling.width = parentRect.width;
+    sash.height = sashHeight;
+    sibling.height = parentRect.height - sashHeight;
+
+    if (position === Position.Top) {
+      sash.top = parentRect.top;
+      sibling.top = parentRect.top + sashHeight;
+    }
+    else {
+      sibling.top = parentRect.top;
+      sash.top = parentRect.top + sibling.height;
+    }
+  }
+
+  // The muntin's orientation lives in its `vertical`/`horizontal` attribute, which
+  // `updateMuntin` doesn't toggle. Force a fresh muntin on axis flip via `update`.
+  if (axisChanged) {
+    parent.id = genId();
+  }
+}
+
+// Resize a pane to `size` along its current split axis, shrinking/growing the
+// sibling to fill the parent. Mirrors the muntin-drag math in `resizable.js`.
+export function updatePaneSize(sash, size) {
+  const parent = sash.parent;
+  if (!parent) return;
+
+  const sibling = parent.getChildSiblingById(sash.id);
+  if (!sibling) return;
+
+  const parsed = parseSize(size);
+  if (isNaN(parsed)) return;
+
+  const parentRect = {
+    top: parent.top,
+    left: parent.left,
+    width: parent.width,
+    height: parent.height,
+  };
+
+  const isLeftRight = parent.isLeftRightSplit();
+  const parentSize = isLeftRight ? parentRect.width : parentRect.height;
+  const newSize = parsed < 1 ? parentSize * parsed : parsed;
+  const siblingSize = parentSize - newSize;
+
+  if (isLeftRight) {
+    sash.width = newSize;
+    sibling.width = siblingSize;
+    if (sash.position === Position.Left) {
+      sibling.left = parentRect.left + newSize;
+    }
+    else {
+      sash.left = parentRect.left + siblingSize;
+    }
+  }
+  else {
+    sash.height = newSize;
+    sibling.height = siblingSize;
+    if (sash.position === Position.Top) {
+      sibling.top = parentRect.top + newSize;
+    }
+    else {
+      sash.top = parentRect.top + siblingSize;
+    }
+  }
 }
 
 function addPaneSashToLeft(targetPaneSash, { size, id, minWidth, minHeight }) {

--- a/src/frame/pane.js
+++ b/src/frame/pane.js
@@ -36,15 +36,15 @@ export default {
    * Update an existing pane's layout: its position (re-places it, keeping its
    * relative size), size, and/or min width/height.
    *
+   * @param {string} id - The Sash ID of the pane to update
    * @param {Object} props
-   * @param {string} props.id - The Sash ID of the pane to update
    * @param {'top'|'right'|'bottom'|'left'} [props.position] - New position of the pane
    * @param {string|number} [props.size] - New size along the split axis (px or fraction)
    * @param {number} [props.minWidth] - New min width
    * @param {number} [props.minHeight] - New min height
    * @returns {Sash} - The updated sash
    */
-  updatePane({ id, position, size, minWidth, minHeight }) {
+  updatePane(id, { position, size, minWidth, minHeight }) {
     const sash = this.rootSash.getById(id);
     if (!sash) throw new Error(`[bwin] No sash found with id ${id} when updating pane`);
 

--- a/src/frame/pane.js
+++ b/src/frame/pane.js
@@ -1,7 +1,12 @@
 import { genBrightColor, genId, createDomNode, swapChildNodes } from '../utils.js';
 import { Position } from '../position.js';
 import { Sash } from '../sash.js';
-import { createPaneElement, addPaneSash, updatePaneElement } from './pane-utils.js';
+import {
+  createPaneElement,
+  addPaneSash,
+  updatePanePosition,
+  updatePaneSize,
+} from './pane-utils.js';
 import { getSashIdFromPane } from '../frame/frame-utils';
 
 export default {
@@ -27,8 +32,31 @@ export default {
     }
   },
 
-  updatePane(sash) {
-    return updatePaneElement(sash);
+  /**
+   * Update an existing pane's layout: its position (re-places it, keeping its
+   * relative size), size, and/or min width/height.
+   *
+   * @param {Object} props
+   * @param {string} props.id - The Sash ID of the pane to update
+   * @param {'top'|'right'|'bottom'|'left'} [props.position] - New position of the pane
+   * @param {string|number} [props.size] - New size along the split axis (px or fraction)
+   * @param {number} [props.minWidth] - New min width
+   * @param {number} [props.minHeight] - New min height
+   * @returns {Sash} - The updated sash
+   */
+  updatePane({ id, position, size, minWidth, minHeight }) {
+    const sash = this.rootSash.getById(id);
+    if (!sash) throw new Error(`[bwin] No sash found with id ${id} when updating pane`);
+
+    if (minWidth != null) sash.minWidth = minWidth;
+    if (minHeight != null) sash.minHeight = minHeight;
+    if (position) updatePanePosition(sash, position);
+    if (size != null) updatePaneSize(sash, size);
+
+    // `update` reconciles the DOM and calls `onPaneUpdate` for each existing pane.
+    this.update();
+
+    return sash;
   },
 
   // Intended to be overridden


### PR DESCRIPTION
Adds an `updatePane` API to mutate an existing pane in place — both its layout (frame layer) and its glass (binary-window layer).

## Frame layer — `updatePane(id, { position, size, minWidth, minHeight })`

- **position** re-places the pane keeping its relative size: same-axis change swaps it with its sibling; cross-axis change reorients the split and rebuilds the muntin.
- **size** resizes along the split axis like a programmatic muntin drag.
- **minWidth / minHeight** update the sash's min sizes (applied on later resizes).
- `update()`'s reconcile loop now calls `updatePaneElement` directly, freeing the `updatePane` name for the new feature.

## Binary-window layer — `updatePane({ id, ..., title, content })`

- Updates the pane's glass **title** and **content** in place (`updateGlass` / `updateGlassTitle` / `updateGlassContent`), on top of the frame-layer layout update.
- Glass **actions** updates are left as a TODO.

## Dev pages

- `update-pane` — two Frames (left/right and top/bottom) to exercise position, size, and min width/height.
- `bwin-update-pane` — a 3-pane BinaryWindow to exercise glass title/content alongside position/size.