### PR TITLE
fix: let the glass title act as a drag handle

### DIFF
--- a/src/binary-window/glass/drag.js
+++ b/src/binary-window/glass/drag.js
@@ -42,9 +42,9 @@ export default {
 
       // Drag starts on the header bar itself or the title, but not on action
       // buttons, tabs, or the action menu — those live inside the header too.
-      const onHeaderBar = event.target.matches('bw-glass-header');
-      const onTitle = event.target.closest('bw-glass-title') !== null;
-      if (!onHeaderBar && !onTitle) return;
+      if (!event.target.matches('bw-glass-header') && !event.target.closest('bw-glass-title')) {
+        return;
+      }
 
       const headerEl = event.target.closest('bw-glass-header');
       if (headerEl.getAttribute('can-drag') === 'false') {

--- a/src/binary-window/glass/drag.js
+++ b/src/binary-window/glass/drag.js
@@ -23,7 +23,11 @@ export default {
       const oldSashId = getSashIdFromPane(activeDragGlassEl);
       this.removePane(oldSashId);
 
-      const newPaneSash = this.addPane(sash.id, { position: dropArea, id: oldSashId, withGlass: false });
+      const newPaneSash = this.addPane(sash.id, {
+        position: dropArea,
+        id: oldSashId,
+        withGlass: false,
+      });
       newPaneSash.domNode.append(activeDragGlassEl);
     }
   },
@@ -34,15 +38,21 @@ export default {
     // It is possible to use `preventDefault` on `mousedown` if `event.target` is a child element
     // But it also prevents text from selection
     document.addEventListener('mousedown', (event) => {
-      if (event.button !== 0 || !event.target.matches('bw-glass-header')) return;
-      if (event.target.getAttribute('can-drag') === 'false') {
+      if (event.button !== 0) return;
+
+      // Drag starts on the header bar itself or the title, but not on action
+      // buttons, tabs, or the action menu — those live inside the header too.
+      const onHeaderBar = event.target.matches('bw-glass-header');
+      const onTitle = event.target.closest('bw-glass-title') !== null;
+      if (!onHeaderBar && !onTitle) return;
+
+      const headerEl = event.target.closest('bw-glass-header');
+      if (headerEl.getAttribute('can-drag') === 'false') {
         // Chrome bug: use `event.preventDefault` to trigger `dragover` event
         // even if there's no `draggable` attribute set
         event.preventDefault();
         return;
       }
-
-      const headerEl = event.target;
 
       const glassEl = headerEl.closest('bw-glass');
       glassEl.setAttribute('draggable', true);
@@ -79,9 +89,7 @@ export default {
       if (activeDragGlassEl) {
         activeDragGlassEl.removeAttribute('draggable');
         // Carry over `can-drop` attribute
-        activeDragGlassEl
-          .closest('bw-pane')
-          .setAttribute('can-drop', activeDragGlassPaneCanDrop);
+        activeDragGlassEl.closest('bw-pane').setAttribute('can-drop', activeDragGlassPaneCanDrop);
         activeDragGlassEl = null;
       }
     });


### PR DESCRIPTION
## What

Pressing and dragging on `bw-glass-title` now starts a glass drag, just like dragging the header bar.

## Why

The `mousedown` handler only started a drag when `event.target` was *exactly* `bw-glass-header`. Since the title is a child of the header, pressing on the title text never initiated a drag — even though the title is the most intuitive drag handle.

## How

- Start the drag when the target is the header bar **or** within `bw-glass-title`.
- Still exclude action buttons, tabs, and the action menu — they live inside the header but aren't inside the title.
- Resolve the header via `closest` so the `can-drag="false"` check reads from the right element.