### PR TITLE
refactor: rename action placement 'list' to 'menu'

### DIFF
--- a/dev/window/bwin-actions.js
+++ b/dev/window/bwin-actions.js
@@ -15,21 +15,21 @@ const updateAction = {
 const dropdownActions = [
   {
     label: 'Action 1',
-    placement: 'list',
+    placement: 'menu',
     onClick: () => {
       alert('Action 1 clicked');
     },
   },
   {
     label: 'Dummy action',
-    placement: 'list',
+    placement: 'menu',
     onClick: () => {
       alert('Dummy action clicked');
     },
   },
   {
     label: 'Dummy action 2',
-    placement: 'list',
+    placement: 'menu',
     onClick: () => {
       alert('Dummy action 2 clicked');
     },
@@ -55,7 +55,7 @@ const settings = {
           actions: [
             {
               label: 'A 10',
-              placement: 'list',
+              placement: 'menu',
               onClick: () => {
                 alert('Another action clicked');
               },

--- a/src/binary-window/glass/glass.js
+++ b/src/binary-window/glass/glass.js
@@ -29,12 +29,12 @@ export class Glass {
   build() {
     const headerEl = document.createElement('bw-glass-header');
 
-    const listActions = Array.isArray(this.actions)
-      ? this.actions.filter((action) => action.placement === 'list')
+    const menuActions = Array.isArray(this.actions)
+      ? this.actions.filter((action) => action.placement === 'menu')
       : [];
 
-    if (listActions.length > 0) {
-      headerEl.append(this.createActionMenu(listActions));
+    if (menuActions.length > 0) {
+      headerEl.append(this.createActionMenu(menuActions));
     }
 
     if (Array.isArray(this.tabs) && this.tabs.length > 0) {


### PR DESCRIPTION
Renames the action `placement` value `'list'` to `'menu'` so it lines up with the `bw-action-menu` element the menu actions render into.

- `glass.js` — filter now matches `placement === 'menu'`; local `listActions` → `menuActions`.
- `dev/window/bwin-actions.js` — updates the four dev usages.

The `'bar'` placement and the `undefined` default (action bar) are unchanged.