### PR TITLE
feat: add pane add/remove lifecycle hooks with veto support

### DIFF
--- a/dev/window/bwin-add-remove-panes.html
+++ b/dev/window/bwin-add-remove-panes.html
@@ -8,7 +8,7 @@
   <body>
     <main>
       <h2>BinaryWindow - add/remove panes</h2>
-      <input id="sash-id" type="text" placeholder="Sash ID" />
+      <input id="sash-id" type="text" placeholder="Sash ID" value="bottom-left" />
       <button id="add-pane">Add pane</button>
       <button id="remove-pane">Remove pane</button>
       <br />

--- a/dev/window/bwin-add-remove-panes.js
+++ b/dev/window/bwin-add-remove-panes.js
@@ -12,8 +12,6 @@ const children1 = [
   ],
 ];
 
-const children2 = [{ id: 'top-pane', size: 0.5, position: 'top' }, { id: 'bottom-pane' }];
-
 const settings = {
   width: 600,
   height: 400,
@@ -22,6 +20,26 @@ const settings = {
 
 const bwin = new BinaryWindow(settings);
 bwin.mount(document.querySelector('#container'));
+
+bwin.onBeforePaneRemove = (paneSash) => {
+  console.log('onBeforePaneRemove:', paneSash);
+  console.log('onBeforePaneRemove - domNode: ', paneSash.domNode);
+  return true;
+};
+
+bwin.onPaneRemove = (paneSash) => {
+  console.log('onPaneRemove:', paneSash);
+  console.log('onPaneRemove - domNode: ', paneSash.domNode);
+};
+
+bwin.onBeforePaneAdd = (targetPaneSash) => {
+  console.log('onBeforePaneAdd:', targetPaneSash);
+  return true;
+};
+
+bwin.onPaneAdd = (targetPaneSash) => {
+  console.log('onPaneAdd:', targetPaneSash);
+};
 
 document.querySelector('#add-pane').addEventListener('click', () => {
   const parentId = document.querySelector('#sash-id').value.trim();

--- a/src/binary-window/binary-window.js
+++ b/src/binary-window/binary-window.js
@@ -60,6 +60,8 @@ export class BinaryWindow extends Frame {
   addPane(targetPaneSashId, props) {
     const { position, size, id, minWidth, minHeight, withGlass = true, ...glassProps } = props;
     const paneSash = super.addPane(targetPaneSashId, { position, size, id, minWidth, minHeight });
+    if (!paneSash) return null;
+
     if (withGlass) {
       const glass = new Glass({ ...glassProps, sash: paneSash, binaryWindow: this });
       paneSash.domNode.append(glass.domNode);
@@ -85,15 +87,11 @@ export class BinaryWindow extends Frame {
   }
 
   removePane(paneSashId) {
-    const paneEl = this.windowElement.querySelector(`[sash-id="${paneSashId}"]`);
-
-    if (paneEl) {
-      super.removePane(paneSashId);
-      return;
-    }
+    super.removePane(paneSashId);
 
     // Remove the glass's sill pot if it was minimized
     const potEl = this.getPotElementBySashId(paneSashId);
+
     if (potEl) {
       potEl.remove();
     }

--- a/src/frame/main.js
+++ b/src/frame/main.js
@@ -16,7 +16,6 @@ export default {
     this.rootSash.walk((sash) => {
       let elem = null;
 
-      // Prepend the new pane, so muntins are always on top
       if (sash.children.length > 0) {
         elem = this.createMuntin(sash);
         this.onMuntinCreate(elem, sash);
@@ -25,6 +24,7 @@ export default {
       else {
         elem = this.createPane(sash);
         this.onPaneCreate(elem, sash);
+        // Prepend the new pane, so muntins are rendered after panes
         this.windowElement.prepend(elem);
       }
 

--- a/src/frame/pane.js
+++ b/src/frame/pane.js
@@ -80,10 +80,12 @@ export default {
     const targetPaneSash = this.rootSash.getById(targetPaneSashId);
     if (!targetPaneSash) throw new Error('[bwin] Parent sash not found when adding pane');
 
+    const mustAdd = this.onBeforePaneAdd(targetPaneSash);
+    if (mustAdd === false) return null;
+
     const newPaneSash = addPaneSash(targetPaneSash, { position, size, id, minWidth, minHeight });
-
     this.update();
-
+    this.onPaneAdd(newPaneSash);
     return newPaneSash;
   },
 
@@ -95,6 +97,12 @@ export default {
   removePane(sashId) {
     const parentSash = this.rootSash.getDescendantParentById(sashId);
     if (!parentSash) throw new Error('[bwin] Parent sash not found when removing pane');
+
+    const sash = this.rootSash.getById(sashId);
+    if (!sash) throw new Error('[bwin] Sash not found when removing pane');
+
+    const mustRemove = this.onBeforePaneRemove(sash);
+    if (mustRemove === false) return;
 
     const siblingSash = parentSash.getChildSiblingById(sashId);
 
@@ -127,6 +135,9 @@ export default {
     }
 
     this.update();
+    // `sash.domNode` still exists at this point,
+    // but was removed from the DOM during `this.update()`
+    this.onPaneRemove(sash);
   },
 
   swapPanes(sourcePaneEl, targetPaneEl) {
@@ -145,6 +156,12 @@ export default {
     sourcePaneEl.setAttribute('can-drop', targetPaneCanDrop);
     targetPaneEl.setAttribute('can-drop', sourcePaneCanDrop);
   },
+
+  // To be overridden by user code
+  onBeforePaneAdd(targetPaneSash) {},
+  onPaneAdd(newPaneSash) {},
+  onBeforePaneRemove(paneSash) {},
+  onPaneRemove(paneSash) {},
 };
 
 function __debug(parentEl) {


### PR DESCRIPTION
Adds overridable lifecycle hooks around pane add/remove on the frame, wired through `BinaryWindow`.

## What changed
- `src/frame/pane.js`: add `onBeforePaneAdd` / `onPaneAdd` / `onBeforePaneRemove` / `onPaneRemove` hooks (no-op by default, meant to be overridden). The `before*` hooks can veto by returning `false` — `addPane` returns `null` and `removePane` bails. `onPaneRemove` fires after `update()`, when `sash.domNode` still exists but is detached from the DOM.
- `src/binary-window/binary-window.js`: `addPane` short-circuits to `null` when the underlying add is vetoed; `removePane` simplified to always delegate then clean up any minimized sill pot.
- `dev/window/bwin-add-remove-panes.{html,js}`: demo the new hooks and default the Sash ID input to `bottom-left`.

## Why
Lets downstream code observe and veto pane add/remove, and run cleanup on removal while the detached node is still reachable.