### PR TITLE
fix: create sill pot after removePane so minimize keeps the pot

### DIFF
--- a/src/binary-window/glass/action.minimize.js
+++ b/src/binary-window/glass/action.minimize.js
@@ -9,19 +9,20 @@ export default {
     const sillEl = binaryWindow.sillElement;
     if (!sillEl) throw new Error(`[bwin] Sill element not found when minimizing`);
 
-    const potEl = createDomNode('<button class="bw-pot" bw-plant="glass" />');
-    sillEl.append(potEl);
-
     const paneEl = event.target.closest('bw-pane');
     const glassEl = event.target.closest('bw-glass');
     const paneSashId = paneEl.getAttribute('sash-id');
     const panePosition = paneEl.getAttribute('position');
 
+    binaryWindow.removePane(paneSashId);
+
+    // Create the "pot" after `removePane`, which destroys the removed pane's pot
+    const potEl = createDomNode('<button class="bw-pot" bw-plant="glass" />');
     potEl.bwGlassElement = glassEl;
     potEl.bwOriginalPosition = panePosition;
     potEl.bwOriginalBoundingRect = getMetricsFromElement(paneEl);
     potEl.bwOriginalSashId = paneSashId;
 
-    binaryWindow.removePane(paneSashId);
+    sillEl.append(potEl);
   },
 };


### PR DESCRIPTION
## What

Minimizing an attached glass produced **no sill pot**, so the glass couldn't be restored.

## Why

Regression from #101, which removed the live-pane guard in `BinaryWindow.removePane`. The minimize action planted the pot *before* calling `removePane`, and `removePane`'s pot-cleanup (matching on `sash-id`) then destroyed the pot it had just planted.

## Fix

Reorder `action.minimize.js` to call `removePane` **first**, then create the pot. After removal there's no matching pot for the cleanup to delete, so the freshly planted pot survives. `binary-window.js` is left untouched.