### PR TITLE
test: reorganize tests into tests/ dir and add CI workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,30 @@
+name: Unit Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 11
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run unit tests
+        run: pnpm test run

--- a/tests/binary-window/binary-window.test.js
+++ b/tests/binary-window/binary-window.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { BinaryWindow } from './binary-window';
+import { BinaryWindow } from '@/binary-window/binary-window';
 
 describe('BinaryWindow#updatePane', () => {
   let containerEl;

--- a/tests/binary-window/detached-glass/detached-glass.test.js
+++ b/tests/binary-window/detached-glass/detached-glass.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { DetachedGlass } from './detached-glass';
+import { DetachedGlass } from '@/binary-window/detached-glass/detached-glass';
 
 const build = (options = {}) => new DetachedGlass({ position: 'center', ...options }).domNode;
 

--- a/tests/binary-window/detached-glass/manager.test.js
+++ b/tests/binary-window/detached-glass/manager.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { detachedGlassManager } from './manager';
+import { detachedGlassManager } from '@/binary-window/detached-glass/manager';
 
 // The manager is a shared singleton; reset its state so tests don't leak into each other.
 beforeEach(() => {
@@ -27,13 +27,10 @@ describe('addDetachedGlass', () => {
     expect(Number(glassEl.style.zIndex)).toBeGreaterThan(0);
   });
 
-  it('plays the open animation by default ([opening])', () => {
+  // The manager is a pure registry: it never animates. Open/close animation
+  // (the `opening`/`closing` attributes) lives in the crud layer.
+  it('does not touch the open animation ([opening])', () => {
     const glassEl = addGlass();
-    expect(glassEl.hasAttribute('opening')).toBe(true);
-  });
-
-  it('skips the open animation when animateOpen is false', () => {
-    const glassEl = addGlass({ animateOpen: false });
     expect(glassEl.hasAttribute('opening')).toBe(false);
   });
 
@@ -107,37 +104,29 @@ describe('bringToFront', () => {
 });
 
 describe('removeDetachedGlass', () => {
-  it('unregisters the glass and resolves with the removed element', async () => {
+  // The manager only unregisters and returns the element synchronously; the crud
+  // layer owns DOM removal and the close animation.
+  it('unregisters the glass and returns the removed element', () => {
     const glassEl = addGlass({ id: 'gone' });
 
-    const removed = await detachedGlassManager.removeDetachedGlass('gone', { animate: false });
+    const removed = detachedGlassManager.removeDetachedGlass('gone');
 
     expect(removed).toBe(glassEl);
     expect(detachedGlassManager.detachedGlassElements).not.toContain(glassEl);
   });
 
-  it('removes the node from the DOM when animate is false', () => {
-    const glassEl = addGlass({ id: 'gone' });
-    document.body.append(glassEl);
-
-    detachedGlassManager.removeDetachedGlass('gone', { animate: false });
-
-    expect(glassEl.isConnected).toBe(false);
-  });
-
-  it('resolves with null when no glass has that id', async () => {
-    await expect(detachedGlassManager.removeDetachedGlass('missing')).resolves.toBeNull();
-  });
-
-  it('defaults animate to true (node stays until the close animation ends)', () => {
+  it('leaves the DOM node in place (caller owns removal)', () => {
     const glassEl = addGlass({ id: 'gone' });
     document.body.append(glassEl);
 
     detachedGlassManager.removeDetachedGlass('gone');
 
-    // Unregistered immediately, but the DOM node waits for `animationend` (never fires in jsdom).
-    expect(detachedGlassManager.detachedGlassElements).not.toContain(glassEl);
-    expect(glassEl.hasAttribute('closing')).toBe(true);
+    expect(glassEl.isConnected).toBe(true);
+    glassEl.remove();
+  });
+
+  it('returns null when no glass has that id', () => {
+    expect(detachedGlassManager.removeDetachedGlass('missing')).toBeNull();
   });
 });
 

--- a/tests/binary-window/utils.test.js
+++ b/tests/binary-window/utils.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { normActions } from './utils';
-import { DEFAULT_GLASS_ACTIONS } from './glass';
-import { DEFAULT_DETACHED_GLASS_ACTIONS } from './detached-glass';
+import { normActions } from '@/binary-window/utils';
+import { DEFAULT_GLASS_ACTIONS } from '@/binary-window/glass';
+import { DEFAULT_DETACHED_GLASS_ACTIONS } from '@/binary-window/detached-glass';
 
 describe('normActions', () => {
   it('returns the builtin actions when actions is undefined', () => {

--- a/tests/config/sash-config.test.js
+++ b/tests/config/sash-config.test.js
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
-import { SashConfig } from './sash-config';
-import { FEAT_DEFAULTS } from './config-root';
+import { SashConfig } from '@/config/sash-config';
+import { FEAT_DEFAULTS } from '@/config/config-root';
 
 test('Instantiate', () => {
   const config = new SashConfig();

--- a/tests/frame/event.test.js
+++ b/tests/frame/event.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import eventModule from './event';
+import eventModule from '@/frame/event';
 
 // Each test gets a fresh emitter, mirroring how `eventModule` is assembled onto
 // a `Frame`/`BinaryWindow` instance (its methods run with `this` as that instance).

--- a/tests/frame/pane-utils.test.js
+++ b/tests/frame/pane-utils.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { addPaneSash } from './pane-utils';
-import { Sash, DEFAULTS } from '../sash';
-import { Position } from '../position';
+import { addPaneSash } from '@/frame/pane-utils';
+import { Sash, DEFAULTS } from '@/sash';
+import { Position } from '@/position';
 
 function makeTargetSash() {
   return new Sash({

--- a/tests/rect.test.js
+++ b/tests/rect.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getIntersectRect } from './rect';
+import { getIntersectRect } from '@/rect';
 
 describe('getIntersectRect', () => {
   it('returns the intersected rect object 1', () => {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseSize, strictAssign, createDomNode } from './utils';
+import { parseSize, strictAssign, createDomNode } from '@/utils';
 
 describe('parseSize', () => {
   it('returns the number when a valid number is passed', () => {


### PR DESCRIPTION
## What

- **Relocate tests** — move all \`*.test.js\` from \`src/\` into a top-level \`tests/\` directory mirroring the \`src/\` layout. Sibling-relative imports rewritten to the \`@/\` alias (already configured in \`vitest.config.js\`).
- **Fix manager tests** — the #102 refactor turned \`detached-glass/manager.js\` into a pure registry (open/close animation, \`opening\`/\`closing\` attrs, and Promise returns moved to the crud layer). Updated the stale tests to assert the registry-only contract.
- **Add CI** — new \`unit-tests\` workflow runs the suite on PR open/synchronize/reopen.

## Notes

- All 74 tests pass.
- \`src/\` source is unchanged; only test files moved + assertions updated.
- The \`unit-tests\` job can be added as a required status check once it runs here.