### PR TITLE
fix: remove windowless glass DOM when animate is false

### DIFF
--- a/src/binary-window/windowless-glass.js
+++ b/src/binary-window/windowless-glass.js
@@ -6,10 +6,8 @@ import { removeDetachedGlassElement } from './detached-glass/utils';
 export function removeWindowlessGlass(id, { animate = true } = {}) {
   const detachedGlassEl = detachedGlassManager.removeDetachedGlass(id);
 
-  if (!animate) {
-    return Promise.resolve(detachedGlassEl);
-  }
-
+  // `removeDetachedGlassElement` removes the element (and backdrop) synchronously
+  // when `animate` is false, so don't short-circuit — that left the DOM orphaned.
   return new Promise((resolve) =>
     removeDetachedGlassElement(detachedGlassEl, animate, () => resolve(detachedGlassEl))
   );


### PR DESCRIPTION
## Problem

`removeWindowlessGlass(id, { animate: false })` short-circuited:

```js
const detachedGlassEl = detachedGlassManager.removeDetachedGlass(id);
if (!animate) {
  return Promise.resolve(detachedGlassEl);
}
```

`detachedGlassManager.removeDetachedGlass(id)` only splices the glass out of the internal tracking array and returns the node — the actual `glassEl.remove()` (and modal backdrop removal) happens **only** inside `removeDetachedGlassElement`. So with `animate: false`, the glass shell (and any backdrop) was left orphaned on `document.body`.

This surfaced in **react-bwin**: when `WindowProvider` unmounts, its cleanup calls `removeWindowlessGlass(id, { animate: false })` for each live glass. React tears down the content portal (inner content disappears) while bwin leaves the empty glass shell on screen.

## Fix

Drop the early return and always delegate to `removeDetachedGlassElement`, which already removes the element + backdrop **synchronously** when `animate` is false. This matches the correct sibling `removeDetachedGlass` in `crud.js`.

## Test plan

- Open a windowless glass, then call `removeWindowlessGlass(id, { animate: false })` — glass and any modal backdrop are removed from `document.body`.
- In react-bwin, unmount the `WindowProvider` with a windowless glass open — no orphaned glass remains (`dev/windowless-glass-unmount.tsx`).