### PR TITLE
fix: no-op when removing an already-removed glass

### DIFF
--- a/src/binary-window/detached-glass/crud.js
+++ b/src/binary-window/detached-glass/crud.js
@@ -64,6 +64,9 @@ export default {
   removeDetachedGlass(id, { animate = true } = {}) {
     const removedGlassEl = detachedGlassManager.removeDetachedGlass(id);
 
+    // Already removed (e.g. closed via its action) — no-op so a stale id is harmless.
+    if (!removedGlassEl) return Promise.resolve(null);
+
     return new Promise((resolve) =>
       removeDetachedGlassElement(removedGlassEl, animate, () => resolve(removedGlassEl))
     );

--- a/src/binary-window/windowless-glass.js
+++ b/src/binary-window/windowless-glass.js
@@ -6,8 +6,9 @@ import { removeDetachedGlassElement } from './detached-glass/utils';
 export function removeWindowlessGlass(id, { animate = true } = {}) {
   const detachedGlassEl = detachedGlassManager.removeDetachedGlass(id);
 
-  // `removeDetachedGlassElement` removes the element (and backdrop) synchronously
-  // when `animate` is false, so don't short-circuit — that left the DOM orphaned.
+  // Already removed (e.g. closed via its action) — no-op so a stale id is harmless.
+  if (!detachedGlassEl) return Promise.resolve(null);
+
   return new Promise((resolve) =>
     removeDetachedGlassElement(detachedGlassEl, animate, () => resolve(detachedGlassEl))
   );


### PR DESCRIPTION
## Problem

`removeWindowlessGlass` and `removeDetachedGlass` pass `detachedGlassManager.removeDetachedGlass(id)` straight into `removeDetachedGlassElement`, which dereferences `detachedGlassEl.id` (via `removeGlassBackdrop`).

`detachedGlassManager.removeDetachedGlass(id)` returns `null` when the id isn't found — which happens whenever the glass was **already removed**, e.g. closed via its built-in close action. Removing it again by a stale id then crashes:

```
Uncaught (in promise) TypeError: Cannot read properties of null (reading 'id')
```

### Repro (via react-bwin)

1. Open two windowless glasses.
2. Close one via its close button (runs the built-in action → `removeWindowlessGlass` directly; react-bwin's live-id set still holds the closed id).
3. Unmount the `WindowProvider` → cleanup calls `removeWindowlessGlass(staleId, { animate: false })` → crash.

## Fix

Guard the `null` return in both remove paths so removing an already-gone glass is a harmless no-op (returns `Promise.resolve(null)`), consistent with the manager already returning `null` for an unknown id.

## Test plan

- Call `removeWindowlessGlass(id)` twice for the same glass — second call resolves to `null`, no throw.
- Same for `removeDetachedGlass(id)`.
- react-bwin: open two windowless glasses, close one, unmount the provider — no error, no orphaned glass.