### PR TITLE
chore: add build:watch script and document react-bwin dev workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,3 +19,30 @@ Create a `.env.local` to set the default minimum width/height (in pixels) for a 
 VITE_DEFAULT_SASH_MIN_WIDTH=100
 VITE_DEFAULT_SASH_MIN_HEIGHT=100
 ```
+
+## Working with react-bwin
+
+[`react-bwin`](https://github.com/bhjsdev/react-bwin) consumes bwin's **built**
+output (`dist/bwin.js`), not `src/`. To develop both together (assuming the
+repos are siblings), link them and rebuild bwin on save:
+
+In `react-bwin`, symlink to your local bwin checkout (don't commit this):
+
+```sh
+pnpm add bwin@link:../bwin
+```
+
+In `bwin`, regenerate `dist/bwin.js` on every change:
+
+```sh
+pnpm build:watch
+```
+
+In `react-bwin`, start the dev server (hot-reloads through the symlink):
+
+```sh
+pnpm dev
+```
+
+`pnpm dev` still works in bwin alongside `build:watch` if you want bwin's own
+dev pages running at the same time.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "dev": "vite --port 7100",
     "build": "vite build",
+    "build:watch": "vite build --watch",
     "test": "vitest",
     "format": "prettier --write .",
     "format:check": "prettier --check .",


### PR DESCRIPTION
## What

- Add a `build:watch` script (`vite build --watch`) that regenerates `dist/bwin.js` on save.
- Document the react-bwin local-development workflow in `CONTRIBUTING.md`.

## Why

react-bwin consumes bwin's **built** output (`dist/bwin.js`), not `src/`. To develop both together you link the repos (`pnpm add bwin@link:../bwin` in react-bwin) and keep bwin's build running in watch mode, so edits to bwin source flow through to react-bwin's dev server via HMR.

The new CONTRIBUTING section spells out the link + watch loop and notes the hand-maintained `bwin.d.ts` type shim caveat.