### PR TITLE
fix: guard module-load standalone features for SSR safety

### DIFF
--- a/src/binary-window/binary-window.js
+++ b/src/binary-window/binary-window.js
@@ -118,7 +118,12 @@ BinaryWindow.assemble(glassModule, detachedGlassModule, trimModule, sillModule);
 BinaryWindow.assembleStatic(windowlessGlassStaticModule);
 
 // Enable features that do not need a BinaryWindow instance
-// e.g. handle pointer events
-glassModule.enableGlassStandaloneFeatures();
-// e.g. detached glass move/resize/activate
-detachedGlassModule.enableDetachedGlassStandaloneFeatures();
+// RATIONAL: these attach document-global listeners at module load, so guard on
+// `document` — importing the package during SSR (e.g. Next.js) has no DOM and
+// would otherwise throw. Re-runs harmlessly once in the browser.
+if (typeof document !== 'undefined') {
+  // e.g. handle pointer events
+  glassModule.enableGlassStandaloneFeatures();
+  // e.g. detached glass move/resize/activate
+  detachedGlassModule.enableDetachedGlassStandaloneFeatures();
+}


### PR DESCRIPTION
## Problem

Importing `bwin` (and therefore `react-bwin`) throws `ReferenceError: document is not defined` under server-side rendering (e.g. Next.js).

`binary-window.js` calls `enableGlassStandaloneFeatures()` / `enableDetachedGlassStandaloneFeatures()` at **module load** to install document-global pointer/activate/move/resize listeners. During SSR there is no DOM, so the import crashes before any component renders. This surfaced when loading the bwin-docs pages that render live React examples.

## Fix

Guard the two module-load calls behind `typeof document !== 'undefined'`. In the browser the guard is always true, so behavior is unchanged — the listeners still install exactly once at import. During SSR the import is now a no-op for these features.

Verified this is the only top-level DOM access in the package; the entry `index.js` is pure imports/exports.