### PR TITLE
feat: add detachedGlassManager.setBaseZIndex

### DIFF
--- a/dev/window/bwin-detached-glass-zindex.html
+++ b/dev/window/bwin-detached-glass-zindex.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script type="module" src="./bwin-detached-glass-zindex.js"></script>
+    <title>Detached Glass z-index</title>
+  </head>
+
+  <body>
+    <main>
+      <h2>BinaryWindow - detached glass base z-index</h2>
+      <div>
+        <label>base z-index <input type="number" id="base-zindex" value="1" /></label>
+        <button id="set-base-zindex">Set base z-index</button>
+      </div>
+      <div>
+        <button id="add-glass">Add detached glass</button>
+      </div>
+      <section id="container"></section>
+    </main>
+  </body>
+</html>

--- a/dev/window/bwin-detached-glass-zindex.js
+++ b/dev/window/bwin-detached-glass-zindex.js
@@ -1,0 +1,32 @@
+import { BinaryWindow, BUILTIN_ACTIONS, detachedGlassManager } from '../../src';
+
+const settings = {
+  width: 777,
+  height: 444,
+  actions: [BUILTIN_ACTIONS],
+  children: [
+    { position: 'left', size: '40%', content: 'Left pane', title: 'Left pane' },
+    { content: 'Right pane', title: 'Right pane' },
+  ],
+};
+
+const bwin = new BinaryWindow(settings);
+bwin.mount(document.querySelector('#container'));
+
+const baseZIndexInput = document.querySelector('#base-zindex');
+
+// Push the base z-index; the next glass raised via bringToFront starts stacking from here.
+document.querySelector('#set-base-zindex').addEventListener('click', () => {
+  detachedGlassManager.setBaseZIndex(Number(baseZIndexInput.value));
+});
+
+let count = 0;
+document.querySelector('#add-glass').addEventListener('click', () => {
+  count += 1;
+  bwin.addDetachedGlass({
+    position: 'center',
+    offset: count * 24,
+    title: `Glass ${count}`,
+    content: `Glass ${count}`,
+  });
+});

--- a/dev/window/bwin-detached-glass.js
+++ b/dev/window/bwin-detached-glass.js
@@ -3,6 +3,7 @@ import {
   DEFAULT_GLASS_ACTIONS,
   BUILTIN_ACTIONS,
   DEFAULT_DETACHED_GLASS_ACTIONS,
+  detachedGlassManager,
 } from '../../src';
 
 const elem = document.createElement('div');

--- a/src/binary-window/detached-glass/manager.js
+++ b/src/binary-window/detached-glass/manager.js
@@ -7,6 +7,10 @@ class DetachedGlassManager {
     this.topZIndex = 1;
   }
 
+  setBaseZIndex(zIndex) {
+    this.topZIndex = zIndex;
+  }
+
   // Caller owns only the DOM `append` (parent differs: `bw-window` vs. `document.body`)
   // and reads the returned element's `style.zIndex` for the windowless modal backdrop.
   addDetachedGlass(options) {

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import './css/theme.css';
 
 export { Frame } from './frame/frame';
 export { BinaryWindow } from './binary-window/binary-window';
+export { detachedGlassManager } from './binary-window/detached-glass/manager';
 export { DEFAULT_GLASS_ACTIONS } from './binary-window/glass';
 export {
   DEFAULT_DETACHED_GLASS_ACTIONS,


### PR DESCRIPTION
## Summary

Expose a `setBaseZIndex` method on the detached-glass manager so consumers can control the base of the detached-glass stacking counter.

## Changes

- **`src/binary-window/detached-glass/manager.js`** — add `setBaseZIndex(zIndex)`, which sets `topZIndex`. Takes effect on the next glass raised via `bringToFront` (not retroactive).
- **`src/index.js`** — export `detachedGlassManager` from the package entry.
- **`dev/window/bwin-detached-glass-zindex.{html,js}`** (new) — dev page with a base-z-index input + button and an "Add glass" button to observe the effect on stacking.